### PR TITLE
Use require.resolve to locate Prism for patching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Use `require.resolve` to locate Prism for patching
+
 
 ## v1.0.0 - 94361b5
 

--- a/script/prism.js
+++ b/script/prism.js
@@ -55,7 +55,7 @@ if (fs.existsSync(base)) fs.rmSync(base, { recursive: true });
 fs.mkdirSync(base, { recursive: true });
 
 // Copy Prism over
-copyRecursively(path.join(__dirname, '..', 'node_modules', 'prismjs'), base);
+copyRecursively(path.dirname(require.resolve('prismjs')), base);
 
 // Patch the core to not use `window` or `global`
 const core = path.join(base, 'prism.js');


### PR DESCRIPTION
## Type of Change

- **PrismJS Integration:** Vendoring

## What issue does this relate to?

N/A

### What should this PR do?

Relies on `require.resolve` to locate the directory that PrismJS is in, rather than a hardcoded constant.

### What are the acceptance criteria?

Package can be installed.