### PR TITLE
Fix heading_id plugin when encountering inline code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Fix heading_id plugin when encountering inline code
 - (patch) Add Actions workflows to repo for linting/testing
 
 

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -46,7 +46,7 @@ const sluggify = string => string.toLowerCase()
  */
 const extractText = token => {
     let res = '';
-    if (token.type === 'text') res += token.content;
+    if (token.type === 'text' || token.type === 'code_inline') res += token.content;
     if (token.children) res += token.children.map(extractText).join('');
     return res;
 };

--- a/modifiers/heading_id.test.js
+++ b/modifiers/heading_id.test.js
@@ -43,6 +43,16 @@ it('handles inline markdown inside headings', () => {
     } ]);
 });
 
+it('handles inline code inside headings', () => {
+    md.render('# Hello `World`!');
+    expect(md.headings).toEqual([ {
+        slug: 'hello-world',
+        content: 'Hello `World`!',
+        text: 'Hello World!',
+        rendered: 'Hello <code>World</code>!',
+    } ]);
+});
+
 it('resets exposed headings between repeat renders', () => {
     md.render('# Hello World!');
     md.render('# Testing');


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** heading_id

## What issue does this relate to?

DODX-5206

### What should this PR do?

When inline code is used within a heading, we should treat this as plain text to be returned in the heading data generated by the heading_id plugin.

### What are the acceptance criteria?

A heading that contains Markdown, including inline code, should correctly return the plain text when run through the heading_id plugin.