### PR TITLE
Do not inject mentions when inside a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Don't inject user mentions inside links
+
 
 ## v1.0.2 - 149f660
 

--- a/rules/user_mention.js
+++ b/rules/user_mention.js
@@ -74,13 +74,13 @@ module.exports = (md, options) => {
 
         // Check what tokens are parents by walking backwards in the tokens until we reach the top level
         const parents = [];
-        let level = state.level;
-        for (let i = state.tokens.length - 1; i >= 0; i--) {
-            if (level === 0) break;
+        let { level } = state;
+        for (let i = state.tokens.length - 1; i >= 0; i -= 1) {
+            if (level <= 0) break;
 
             const token = state.tokens[i];
             if (token.level === level - 1 && token.nesting > 0) {
-                level = level - token.nesting;
+                level -= token.nesting;
                 parents.push(token);
             }
         }

--- a/rules/user_mention.test.js
+++ b/rules/user_mention.test.js
@@ -54,6 +54,11 @@ it('handles a mention with text before (double new line)', () => {
 `);
 });
 
+it('does not inject mentions inside links', () => {
+    expect(md.render('[test@test](https://test.com)')).toBe(`<p><a href="https://test.com">test@test</a></p>
+`);
+});
+
 const mdPattern = require('markdown-it')().use(require('./user_mention'), { pattern: /[a-z]+/i });
 
 it('handles a mention using a specific pattern', () => {

--- a/rules/user_mention.test.js
+++ b/rules/user_mention.test.js
@@ -66,6 +66,11 @@ it('handles a mention using a specific pattern', () => {
 `);
 });
 
+it('handles a mention inside other markdown when using a specific pattern', () => {
+    expect(mdPattern.render('hello **@test**, thanks')).toBe(`<p>hello <strong><a href="/users/test">@test</a></strong>, thanks</p>
+`);
+});
+
 const mdPath = require('markdown-it')().use(require('./user_mention'), {
     /**
      * Custom path function, prepending the world subdirectory to the mention.

--- a/rules/user_mention.test.js
+++ b/rules/user_mention.test.js
@@ -59,6 +59,11 @@ it('does not inject mentions inside links', () => {
 `);
 });
 
+it('handles a mention that contains markdown', () => {
+    expect(md.render('**@test**')).toBe(`<p>**<a href="/users/test**">@test**</a></p>
+`);
+});
+
 const mdPattern = require('markdown-it')().use(require('./user_mention'), { pattern: /[a-z]+/i });
 
 it('handles a mention using a specific pattern', () => {
@@ -78,10 +83,15 @@ const mdPath = require('markdown-it')().use(require('./user_mention'), {
      * @param {string} mention User mention to generate a URL path for.
      * @returns {string}
      */
-    path: mention => `/world/${mention}`,
+    path: mention => (mention === 'blank' ? '' : `/world/${mention}`),
 });
 
 it('handles a mention using a specific link path', () => {
     expect(mdPath.render('hello @test')).toBe(`<p>hello <a href="/world/test">@test</a></p>
+`);
+});
+
+it('does not inject mentions when there is no path', () => {
+    expect(mdPath.render('hello @blank')).toBe(`<p>hello @blank</p>
 `);
 });


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** user_mention

## What issue does this relate to?

DODX-5308

### What should this PR do?

Bug fix for the user mentions plugin logic, stopping it from injecting mentions within an existing link, which was previously caused invalid HTML and broken links to be generated.

### What are the acceptance criteria?

When a mention is used within an existing markdown link, the mention will be ignored and left as the existing link.