### PR TITLE
Fix issue with HTML preservation inside a multi-line token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Fix issue with HTML preservation inside a multi-line token
 - (patch) Don't inject user mentions inside links
 
 

--- a/modifiers/prismjs.test.js
+++ b/modifiers/prismjs.test.js
@@ -92,6 +92,14 @@ describe('HTML preservation', () => {
 `);
     });
 
+    it('handles HTML spanning multi-line tokens in the code block', () => {
+        expect(mdHtml.render('```go\n<^>data := `<^>\n  <^>test<^>\n<^>`<^>\n```')).toBe(`<pre class="language-go"><code class="language-go"><mark>data <span class="token operator">:=</span> <span class="token string">\`</span></mark><span class="token string">
+  <mark>test</mark>
+<mark>\`</mark></span>
+</code></pre>
+`);
+    });
+
     it('handles HTML outside the code block', () => {
         expect(mdHtml.render('```typescript\n[label test/hello/world.ts]\nconst test: number = 1;\n```')).toBe(`<div class="code-label" title="test/hello/world.ts">test/hello/world.ts</div>
 <pre class="language-typescript"><code class="language-typescript"><span class="token keyword">const</span> test<span class="token operator">:</span> <span class="token builtin">number</span> <span class="token operator">=</span> <span class="token number">1</span><span class="token punctuation">;</span>

--- a/util/dom_utils.js
+++ b/util/dom_utils.js
@@ -98,10 +98,10 @@ const domOffsetNode = (node, offset, root, nextOnExact = false) => {
  * @param {Node} root Node to consider the root of the tree.
  * @param {Node} node Node to split.
  * @param {?number} [offset=null] Optional offset to split at.
- * @param {boolean} [nodeInRight=false] If the node to split on should be in the right tree of the split.
+ * @param {boolean} [nodeInRight=true] If the node to split on should be in the right tree of the split.
  * @returns {{left: Node[], right: Node[]}}
  */
-const domSplit = (root, node, offset = null, nodeInRight = false) => {
+const domSplit = (root, node, offset = null, nodeInRight = true) => {
     if (!root.contains(node)) throw new Error('Node is not a child of root');
 
     // Handle offset in a node

--- a/util/prism_keep_html.js
+++ b/util/prism_keep_html.js
@@ -199,7 +199,7 @@ const plugin = Prism => {
 
             // Split the DOM and get the middle
             // Very loosely equivalent to using DOM Level 2 Range#extractContents
-            const splitOpen = domSplit(ancestor, openNode, openPos, true);
+            const splitOpen = domSplit(ancestor, openNode, openPos);
             [ closeNode, closePos ] = domOffsetNode(closeNode, closePos, root); // Update based on open split
             const splitClose = domSplit(ancestor, closeNode, closePos);
             const middle = splitOpen.right.filter(n => splitClose.left.includes(n));


### PR DESCRIPTION
## Type of Change

- **PrismJS Integration:** prism_keep_html plugin

## What issue does this relate to?

DODX-5226

### What should this PR do?

Fixes an issue observed when a highlight ended inside a multi-line token, where the split in the HTML preservation would be off by one token, resulting in incorrect preservation of the HTML.

I'm not 100% happy with this fix in that I'm not sure I've really found the root cause, but I could see that the issue was indeed that the splitting was off by one character when doing the closing split for HTML preservation, or rather, the closing node that was split on ended up in the wrong side of the tree.

The change in this PR fixes that edge case, and does not break any other tests relating to highlighting or HTML preservation, so I'm confident this doesn't appear to make things worse.

This PR includes a change to the signature of `domSplit` within `dom_utils`, so is breaking in that regard, but that is not an intentionally exposed or documented part of this package, so I am considering this to be a patch still.

### What are the acceptance criteria?

When a highlight is encountered ending inside a multi-line token in a syntax-highlighted code block, the highlight is rendered correctly.

| Before | After |
|--------|-------|
| ![image](https://user-images.githubusercontent.com/12371363/162064803-70a877f3-8e09-47b0-b2d4-33333a4f1e2d.png) | ![image](https://user-images.githubusercontent.com/12371363/162065303-3ff7ba1c-c665-4b09-ac8e-e649be612ecb.png) |