### PR TITLE
Update jsdoc to mark @modules and @privates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea/
 node_modules/
 vendor/prismjs/
+jsdoc/

--- a/.jsdoc.json
+++ b/.jsdoc.json
@@ -1,0 +1,19 @@
+{
+  "plugins": [
+    "jsdoc-tsimport-plugin"
+  ],
+  "source": {
+    "include": [
+      "index.js",
+      "modifiers",
+      "rules",
+      "util"
+    ],
+    "excludePattern": "\\.test\\.js$"
+  },
+  "opts": {
+    "recurse": true,
+    "package": "package.json",
+    "destination": "jsdoc"
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Update jsdoc to mark @modules and @privates
 - (patch) Fix issue with HTML preservation inside a multi-line token
 - (patch) Don't inject user mentions inside links
 

--- a/index.js
+++ b/index.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit
+ */
+
 const safeObject = require('./util/safe_object');
 
 /**

--- a/modifiers/fence_classes.js
+++ b/modifiers/fence_classes.js
@@ -59,6 +59,7 @@ module.exports = (md, options) => {
      * @param {string} tagName Name of the HTML tag to filter classes for.
      * @param {string} content Full HTML snippet in which the HTML tag is located.
      * @returns {string}
+     * @private
      */
     const filterTag = (tagName, content) => {
         // Locate the tag
@@ -86,6 +87,7 @@ module.exports = (md, options) => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original Original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the rendered content

--- a/modifiers/fence_classes.js
+++ b/modifiers/fence_classes.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/fence_classes
+ */
+
 const safeObject = require('../util/safe_object');
 const findTagOpen = require('../util/find_tag_open');
 const findAttr = require('../util/find_attr');

--- a/modifiers/fence_classes.js
+++ b/modifiers/fence_classes.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/fence_classes
+ * @module modifiers/fence_classes
  */
 
 const safeObject = require('../util/safe_object');

--- a/modifiers/fence_environment.js
+++ b/modifiers/fence_environment.js
@@ -51,6 +51,7 @@ module.exports = (md, options) => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original The original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the token

--- a/modifiers/fence_environment.js
+++ b/modifiers/fence_environment.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/fence_environment
+ * @module modifiers/fence_environment
  */
 
 const safeObject = require('../util/safe_object');

--- a/modifiers/fence_environment.js
+++ b/modifiers/fence_environment.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/fence_environment
+ */
+
 const safeObject = require('../util/safe_object');
 
 /**

--- a/modifiers/fence_label.js
+++ b/modifiers/fence_label.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/fence_label
+ * @module modifiers/fence_label
  */
 
 const safeObject = require('../util/safe_object');

--- a/modifiers/fence_label.js
+++ b/modifiers/fence_label.js
@@ -51,6 +51,7 @@ module.exports = (md, options) => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original Original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the token

--- a/modifiers/fence_label.js
+++ b/modifiers/fence_label.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/fence_label
+ */
+
 const safeObject = require('../util/safe_object');
 
 /**

--- a/modifiers/fence_pre_attrs.js
+++ b/modifiers/fence_pre_attrs.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/fence_pre_attrs
+ */
+
 const findTagOpen = require('../util/find_tag_open');
 
 /**

--- a/modifiers/fence_pre_attrs.js
+++ b/modifiers/fence_pre_attrs.js
@@ -39,6 +39,7 @@ module.exports = md => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original Original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the rendered content

--- a/modifiers/fence_pre_attrs.js
+++ b/modifiers/fence_pre_attrs.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/fence_pre_attrs
+ * @module modifiers/fence_pre_attrs
  */
 
 const findTagOpen = require('../util/find_tag_open');

--- a/modifiers/fence_prefix.js
+++ b/modifiers/fence_prefix.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/fence_prefix
+ * @module modifiers/fence_prefix
  */
 
 const safeObject = require('../util/safe_object');

--- a/modifiers/fence_prefix.js
+++ b/modifiers/fence_prefix.js
@@ -30,6 +30,7 @@ const findTagOpen = require('../util/find_tag_open');
  * @param {import('markdown-it').Token} token MarkdownIt token to determine the prefix for.
  * @param {string} delimiter String to split the token's info string on.
  * @returns {?(function(string, number): string)}
+ * @private
  */
 const getPrefix = (token, delimiter) => {
     // Get all flags passed in token
@@ -41,6 +42,7 @@ const getPrefix = (token, delimiter) => {
      * @param {string[]} classes Classes to apply to the token, overwriting current.
      * @param {string[]} remove Flags to remove from the token's info.
      * @param {string[]} [add=[]] Flags to add to the token's info.
+     * @private
      */
     const update = (classes, remove, add = []) => {
         remove.forEach(flag => flags.delete(flag));
@@ -121,6 +123,7 @@ module.exports = (md, options) => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original Original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the token

--- a/modifiers/fence_prefix.js
+++ b/modifiers/fence_prefix.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/fence_prefix
+ */
+
 const safeObject = require('../util/safe_object');
 const findTagOpen = require('../util/find_tag_open');
 

--- a/modifiers/fence_secondary_label.js
+++ b/modifiers/fence_secondary_label.js
@@ -51,6 +51,7 @@ module.exports = (md, options) => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original Original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the token

--- a/modifiers/fence_secondary_label.js
+++ b/modifiers/fence_secondary_label.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/fence_secondary_label
+ */
+
 const safeObject = require('../util/safe_object');
 const findTagOpen = require('../util/find_tag_open');
 

--- a/modifiers/fence_secondary_label.js
+++ b/modifiers/fence_secondary_label.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/fence_secondary_label
+ * @module modifiers/fence_secondary_label
  */
 
 const safeObject = require('../util/safe_object');

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/heading_id
+ */
+
 const safeObject = require('../util/safe_object');
 
 /**

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -32,6 +32,7 @@ const safeObject = require('../util/safe_object');
  *
  * @param {string} string String to be sluggified.
  * @returns {string}
+ * @private
  */
 const sluggify = string => string.toLowerCase()
     .replace(/\W+/g, '-')
@@ -43,6 +44,7 @@ const sluggify = string => string.toLowerCase()
  *
  * @param {import('markdown-it/lib/token')} token Token to extract text from.
  * @returns {string}
+ * @private
  */
 const extractText = token => {
     let res = '';
@@ -78,6 +80,7 @@ module.exports = (md, options) => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} [original] Original render function. Defaults to `renderToken`.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the token
@@ -114,6 +117,7 @@ module.exports = (md, options) => {
      *
      * @param {function(string, *?): string} original Original render function to wrap.
      * @returns {function(string, *?): string}
+     * @private
      */
     const reset = original => (src, env) => {
         md.headings = [];

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/heading_id
+ * @module modifiers/heading_id
  */
 
 const safeObject = require('../util/safe_object');

--- a/modifiers/prismjs.js
+++ b/modifiers/prismjs.js
@@ -39,6 +39,7 @@ const languageAliases = Object.entries(components.languages).reduce((aliases, [ 
  * Helper to load in a language if not yet loaded.
  *
  * @param {string} language Prism language name to be loaded.
+ * @private
  */
 const loadLanguage = language => {
     if (language in Prism.languages) return;
@@ -55,6 +56,7 @@ require('../util/prism_keep_html')(Prism);
  * @param {string} html HTML snippet that contains the code block.
  * @param {{original: string, clean: string}} language Language information (user-provided original, and clean name).
  * @returns {{before: string, after: string, inside: string}}
+ * @private
  */
 const extractCodeBlock = (html, language) => {
     let workingHtml = html;
@@ -136,6 +138,7 @@ module.exports = (md, options) => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original Original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const render = original => (tokens, idx, opts, env, self) => {
         // Get the token

--- a/modifiers/prismjs.js
+++ b/modifiers/prismjs.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/modifiers/prismjs
+ * @module modifiers/prismjs
  */
 
 const Prism = require('../vendor/prismjs');

--- a/modifiers/prismjs.js
+++ b/modifiers/prismjs.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/modifiers/prismjs
+ */
+
 const Prism = require('../vendor/prismjs');
 const components = require('../vendor/prismjs/components');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,8 @@
         "eslint-plugin-import": "^2.25.4",
         "eslint-plugin-jsdoc": "^38.0.6",
         "jest": "^27.5.1",
+        "jsdoc": "^3.6.10",
+        "jsdoc-tsimport-plugin": "^1.0.5",
         "markdown-it": "^12.3.2"
       }
     },
@@ -1429,6 +1431,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -1534,6 +1542,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/browserslist"
+      }
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/chalk": {
@@ -3964,6 +3984,50 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "3.6.10",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
+      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.9.4",
+        "@types/markdown-it": "^12.2.3",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^4.0.1",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=8.15.0"
+      }
+    },
+    "node_modules/jsdoc-tsimport-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-tsimport-plugin/-/jsdoc-tsimport-plugin-1.0.5.tgz",
+      "integrity": "sha512-6mvyF+tXdanf3zxEumTF9Uf/sXGlANP+XohSuiJiOVVWPGxi+3f2a2sy5Ew3W+0PMYUkcGYNxfYd5mMZsIHQpg==",
+      "dev": true
+    },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
@@ -4062,6 +4126,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
+      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.14.0"
       }
     },
     "node_modules/kleur": {
@@ -4186,6 +4259,28 @@
         "markdown-it": "bin/markdown-it.js"
       }
     },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.5.0.tgz",
+      "integrity": "sha512-ii8jRFS4Sxny0nevOOQZqZKswcZyXnD00AlPKctM0PkNRVsT1/2fQMQPXAdWmRz9kYrMupElsEwCikR7Fd2JFQ==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "dev": true,
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -4258,6 +4353,18 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "dev": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -4669,6 +4776,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/requizzle": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
@@ -5031,6 +5147,12 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "node_modules/taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
     "node_modules/terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -5221,6 +5343,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "dev": true
     },
     "node_modules/universalify": {
       "version": "0.1.2",
@@ -5443,6 +5571,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
     },
     "node_modules/y18n": {
@@ -6604,6 +6738,12 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "dev": true
+    },
     "brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -6684,6 +6824,15 @@
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
       "integrity": "sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==",
       "dev": true
+    },
+    "catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.15"
+      }
     },
     "chalk": {
       "version": "4.1.2",
@@ -8509,6 +8658,44 @@
         "argparse": "^2.0.1"
       }
     },
+    "js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dev": true,
+      "requires": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
+    "jsdoc": {
+      "version": "3.6.10",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.10.tgz",
+      "integrity": "sha512-IdQ8ppSo5LKZ9o3M+LKIIK8i00DIe5msDvG3G81Km+1dhy0XrOWD0Ji8H61ElgyEj/O9KRLokgKbAM9XX9CJAg==",
+      "dev": true,
+      "requires": {
+        "@babel/parser": "^7.9.4",
+        "@types/markdown-it": "^12.2.3",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^4.0.1",
+        "markdown-it": "^12.3.2",
+        "markdown-it-anchor": "^8.4.1",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
+        "underscore": "~1.13.2"
+      }
+    },
+    "jsdoc-tsimport-plugin": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/jsdoc-tsimport-plugin/-/jsdoc-tsimport-plugin-1.0.5.tgz",
+      "integrity": "sha512-6mvyF+tXdanf3zxEumTF9Uf/sXGlANP+XohSuiJiOVVWPGxi+3f2a2sy5Ew3W+0PMYUkcGYNxfYd5mMZsIHQpg==",
+      "dev": true
+    },
     "jsdoc-type-pratt-parser": {
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/jsdoc-type-pratt-parser/-/jsdoc-type-pratt-parser-2.2.5.tgz",
@@ -8582,6 +8769,12 @@
       "requires": {
         "minimist": "^1.2.5"
       }
+    },
+    "klaw": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-4.0.1.tgz",
+      "integrity": "sha512-pgsE40/SvC7st04AHiISNewaIMUbY5V/K8b21ekiPiFoYs/EYSdsGa+FJArB1d441uq4Q8zZyIxvAzkGNlBdRw==",
+      "dev": true
     },
     "kleur": {
       "version": "3.0.3",
@@ -8681,6 +8874,19 @@
         "uc.micro": "^1.0.5"
       }
     },
+    "markdown-it-anchor": {
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.5.0.tgz",
+      "integrity": "sha512-ii8jRFS4Sxny0nevOOQZqZKswcZyXnD00AlPKctM0PkNRVsT1/2fQMQPXAdWmRz9kYrMupElsEwCikR7Fd2JFQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "marked": {
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
+      "dev": true
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -8737,6 +8943,12 @@
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "dev": true
     },
     "ms": {
@@ -9040,6 +9252,15 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "requizzle": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "resolve": {
       "version": "1.21.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.21.0.tgz",
@@ -9317,6 +9538,12 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
+    "taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "dev": true
+    },
     "terminal-link": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/terminal-link/-/terminal-link-2.1.1.tgz",
@@ -9467,6 +9694,12 @@
         "has-symbols": "^1.0.2",
         "which-boxed-primitive": "^1.0.2"
       }
+    },
+    "underscore": {
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.2.tgz",
+      "integrity": "sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==",
+      "dev": true
     },
     "universalify": {
       "version": "0.1.2",
@@ -9641,6 +9874,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    },
+    "xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint": "eslint \"{*,@(modifiers|rules|script|util)/**/*}.js\"",
     "lint:fix": "npm run lint -- --fix",
+    "jsdoc": "jsdoc -c .jsdoc.json",
     "test": "jest",
     "postinstall": "node script/prism.js"
   },
@@ -27,6 +28,8 @@
     "eslint-plugin-import": "^2.25.4",
     "eslint-plugin-jsdoc": "^38.0.6",
     "jest": "^27.5.1",
+    "jsdoc": "^3.6.10",
+    "jsdoc-tsimport-plugin": "^1.0.5",
     "markdown-it": "^12.3.2"
   },
   "dependencies": {

--- a/rules/embeds/asciinema.js
+++ b/rules/embeds/asciinema.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/asciinema
+ * @module rules/embeds/asciinema
  */
 
 /**

--- a/rules/embeds/asciinema.js
+++ b/rules/embeds/asciinema.js
@@ -17,6 +17,10 @@ limitations under the License.
 'use strict';
 
 /**
+ * @module @digitalocean/do-markdownit/rules/embeds/asciinema
+ */
+
+/**
  * Add support for [Asciinema](http://asciinema.org/) embeds in Markdown, as block syntax.
  *
  * The basic syntax is `[asciinema <id>]`. E.g. `[asciinema 325730]`.

--- a/rules/embeds/asciinema.js
+++ b/rules/embeds/asciinema.js
@@ -38,6 +38,7 @@ module.exports = md => {
      * Parsing rule for asciinema markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const asciinemaRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -86,6 +87,7 @@ module.exports = md => {
      * Rendering rule for asciinema markup.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.asciinema = (tokens, index) => {
         const token = tokens[index];

--- a/rules/embeds/callout.js
+++ b/rules/embeds/callout.js
@@ -65,6 +65,7 @@ module.exports = (md, options) => {
      * Parsing rule for callout markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const calloutRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -160,6 +161,7 @@ module.exports = (md, options) => {
      * Rendering rule for the start of a callout.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.callout_open = (tokens, index) => {
         const token = tokens[index];
@@ -173,6 +175,7 @@ module.exports = (md, options) => {
      * Rendering rule for the end of a callout.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.callout_close = () => '</div>\n';
 
@@ -180,6 +183,7 @@ module.exports = (md, options) => {
      * Rendering rule for the start of a callout label inside a callout.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.callout_label_open = () => `<p class="${md.utils.escapeHtml(optsObj.labelClass || 'callout-label')}">`;
 
@@ -187,6 +191,7 @@ module.exports = (md, options) => {
      * Rendering rule for the end of a callout label inside a callout.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.callout_label_close = () => '</p>\n';
 };

--- a/rules/embeds/callout.js
+++ b/rules/embeds/callout.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/callout
+ * @module rules/embeds/callout
  */
 
 const safeObject = require('../../util/safe_object');

--- a/rules/embeds/callout.js
+++ b/rules/embeds/callout.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/embeds/callout
+ */
+
 const safeObject = require('../../util/safe_object');
 
 /**

--- a/rules/embeds/codepen.js
+++ b/rules/embeds/codepen.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/embeds/codepen
+ */
+
 const safeObject = require('../../util/safe_object');
 
 /**

--- a/rules/embeds/codepen.js
+++ b/rules/embeds/codepen.js
@@ -55,6 +55,7 @@ module.exports = md => {
      * Parsing rule for Codepen markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const codepenRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -124,6 +125,7 @@ module.exports = md => {
      * Parsing rule to inject the Codepen script.
      *
      * @type {import('markdown-it').RuleCore}
+     * @private
      */
     const codepenScriptRule = state => {
         // Check if we need to inject the script
@@ -144,6 +146,7 @@ module.exports = md => {
      * Rendering rule for Codepen markup.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.codepen = (tokens, index) => {
         const token = tokens[index];

--- a/rules/embeds/codepen.js
+++ b/rules/embeds/codepen.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/codepen
+ * @module rules/embeds/codepen
  */
 
 const safeObject = require('../../util/safe_object');

--- a/rules/embeds/dns.js
+++ b/rules/embeds/dns.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/dns
+ * @module rules/embeds/dns
  */
 
 const safeObject = require('../../util/safe_object');

--- a/rules/embeds/dns.js
+++ b/rules/embeds/dns.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/embeds/dns
+ */
+
 const safeObject = require('../../util/safe_object');
 
 /**

--- a/rules/embeds/dns.js
+++ b/rules/embeds/dns.js
@@ -49,6 +49,7 @@ module.exports = md => {
      * Parsing rule for DNS lookup markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const dnsRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -98,6 +99,7 @@ module.exports = md => {
      * Parsing rule to inject the DNS lookup script.
      *
      * @type {import('markdown-it').RuleCore}
+     * @private
      */
     const dnsScriptRule = state => {
         // Check if we need to inject the script
@@ -118,6 +120,7 @@ module.exports = md => {
      * Rendering rule for DNS lookup markup.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.dns = (tokens, index) => {
         const token = tokens[index];

--- a/rules/embeds/glob.js
+++ b/rules/embeds/glob.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/glob
+ * @module rules/embeds/glob
  */
 
 const safeObject = require('../../util/safe_object');

--- a/rules/embeds/glob.js
+++ b/rules/embeds/glob.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/embeds/glob
+ */
+
 const safeObject = require('../../util/safe_object');
 
 /**

--- a/rules/embeds/glob.js
+++ b/rules/embeds/glob.js
@@ -52,6 +52,7 @@ module.exports = md => {
      * Parsing rule for glob markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const globRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -113,6 +114,7 @@ module.exports = md => {
      * Parsing rule to inject the glob script.
      *
      * @type {import('markdown-it').RuleCore}
+     * @private
      */
     const globScriptRule = state => {
         // Check if we need to inject the script
@@ -133,6 +135,7 @@ module.exports = md => {
      * Rendering rule for glob markup.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.glob = (tokens, index) => {
         const token = tokens[index];

--- a/rules/embeds/rsvp_button.js
+++ b/rules/embeds/rsvp_button.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/rsvp_button
+ * @module rules/embeds/rsvp_button
  */
 
 const safeObject = require('../../util/safe_object');

--- a/rules/embeds/rsvp_button.js
+++ b/rules/embeds/rsvp_button.js
@@ -51,6 +51,7 @@ module.exports = (md, options) => {
      * Parsing rule for RSVP button markup.
      *
      * @type {import('markdown-it/lib/parser_inline').RuleInline}
+     * @private
      */
     const rsvpButtonRule = (state, silent) => {
         // If silent, don't replace
@@ -91,6 +92,7 @@ module.exports = (md, options) => {
      * Rendering rule for RSVP button markup.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.rsvp_button = (tokens, index) => {
         const token = tokens[index];

--- a/rules/embeds/rsvp_button.js
+++ b/rules/embeds/rsvp_button.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/embeds/rsvp_button
+ */
+
 const safeObject = require('../../util/safe_object');
 
 /**

--- a/rules/embeds/terminal_button.js
+++ b/rules/embeds/terminal_button.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/terminal_button
+ * @module rules/embeds/terminal_button
  */
 
 const safeObject = require('../../util/safe_object');

--- a/rules/embeds/terminal_button.js
+++ b/rules/embeds/terminal_button.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/embeds/terminal_button
+ */
+
 const safeObject = require('../../util/safe_object');
 
 /**

--- a/rules/embeds/terminal_button.js
+++ b/rules/embeds/terminal_button.js
@@ -52,6 +52,7 @@ module.exports = (md, options) => {
      * Parsing rule for terminal markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const terminalRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -97,6 +98,7 @@ module.exports = (md, options) => {
      * Rendering rule for terminal markup.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.terminal = (tokens, index) => {
         const token = tokens[index];

--- a/rules/embeds/youtube.js
+++ b/rules/embeds/youtube.js
@@ -17,6 +17,10 @@ limitations under the License.
 'use strict';
 
 /**
+ * @module @digitalocean/do-markdownit/rules/embeds/youtube
+ */
+
+/**
  * Add support for [YouTube](http://youtube.com/) embeds in Markdown, as block syntax.
  *
  * The basic syntax is `[youtube <id>]`. E.g. `[youtube iom_nhYQIYk]`.

--- a/rules/embeds/youtube.js
+++ b/rules/embeds/youtube.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/embeds/youtube
+ * @module rules/embeds/youtube
  */
 
 /**

--- a/rules/embeds/youtube.js
+++ b/rules/embeds/youtube.js
@@ -37,6 +37,7 @@ module.exports = md => {
      * Parsing rule for YouTube markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const youtubeRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -85,6 +86,7 @@ module.exports = md => {
      * Rendering rule for YouTube markup.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.youtube = (tokens, index) => {
         const token = tokens[index];

--- a/rules/highlight.js
+++ b/rules/highlight.js
@@ -46,6 +46,7 @@ module.exports = md => {
      * Parsing rule for highlight markup.
      *
      * @type {import('markdown-it/lib/parser_inline').RuleInline}
+     * @private
      */
     const highlightRule = (state, silent) => {
         // If silent, don't replace
@@ -90,6 +91,7 @@ module.exports = md => {
      *
      * @param {import('markdown-it/lib/renderer').RenderRule} original Original render function to wrap.
      * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     const code = original => (tokens, idx, options, env, self) => original(tokens, idx, options, env, self)
         // Run the original renderer, replacing any pairs of escaped markers

--- a/rules/highlight.js
+++ b/rules/highlight.js
@@ -17,6 +17,10 @@ limitations under the License.
 'use strict';
 
 /**
+ * @module @digitalocean/do-markdownit/rules/highlight
+ */
+
+/**
  * Add support for highlight markup across all Markdown, including inside code.
  *
  * The syntax for highlighting text is `<^>`. E.g. `<^>hello world<^>`.

--- a/rules/highlight.js
+++ b/rules/highlight.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/highlight
+ * @module rules/highlight
  */
 
 /**

--- a/rules/html_comment.js
+++ b/rules/html_comment.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/html_comment
+ */
+
 const safeObject = require('../util/safe_object');
 
 /**

--- a/rules/html_comment.js
+++ b/rules/html_comment.js
@@ -48,6 +48,7 @@ module.exports = (md, options) => {
      * Parsing rule for remove inline HTML comments.
      *
      * @type {import('markdown-it/lib/parser_inline').RuleInline}
+     * @private
      */
     const htmlCommentInlineRule = (state, silent) => {
         // If silent, don't replace
@@ -82,6 +83,7 @@ module.exports = (md, options) => {
      * Parsing rule for remove block HTML comments.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
      */
     const htmlCommentBlockRule = (state, startLine, endLine, silent) => {
         // If silent, don't replace
@@ -129,6 +131,7 @@ module.exports = (md, options) => {
      * Noop rendering HTML comments.
      *
      * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
      */
     md.renderer.rules.html_comment = () => '';
 };

--- a/rules/html_comment.js
+++ b/rules/html_comment.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/html_comment
+ * @module rules/html_comment
  */
 
 const safeObject = require('../util/safe_object');

--- a/rules/user_mention.js
+++ b/rules/user_mention.js
@@ -29,6 +29,7 @@ const safeObject = require('../util/safe_object');
  *
  * @param {string} mention User mention to generate a URL path for.
  * @returns {string}
+ * @private
  */
 const path = mention => `/users/${mention}`;
 
@@ -52,6 +53,7 @@ module.exports = (md, options) => {
      * Parsing rule for user mentions.
      *
      * @type {import('markdown-it/lib/parser_inline').RuleInline}
+     * @private
      */
     const userMentionRule = (state, silent) => {
         // If silent, don't replace

--- a/rules/user_mention.js
+++ b/rules/user_mention.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/rules/user_mention
+ * @module rules/user_mention
  */
 
 const safeObject = require('../util/safe_object');

--- a/rules/user_mention.js
+++ b/rules/user_mention.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/rules/user_mention
+ */
+
 const safeObject = require('../util/safe_object');
 
 /**

--- a/script/prism.js
+++ b/script/prism.js
@@ -24,6 +24,7 @@ const path = require('path');
  *
  * @param {string} dir Directory to explore.
  * @returns {string[]}
+ * @private
  */
 const getFilesInDir = dir => fs.readdirSync(dir, { withFileTypes: true })
     .flatMap(file => (file.isDirectory() ? getFilesInDir(path.join(dir, file.name)) : path.join(dir, file.name)));
@@ -33,6 +34,7 @@ const getFilesInDir = dir => fs.readdirSync(dir, { withFileTypes: true })
  *
  * @param {string} src Directory to copy from.
  * @param {string} dest Directory to copy to.
+ * @private
  */
 const copyRecursively = (src, dest) => {
     const exists = fs.existsSync(src);
@@ -81,6 +83,7 @@ fs.writeFileSync(
  *
  * @param {string} source Source code of the component.
  * @returns {string}
+ * @private
  */
 const template = source => `const component = Prism => {\n\t${source.replace(/\n/g, '\n\t')}\n};\n\nif (typeof module !== 'undefined' && module.exports) {\n\tmodule.exports = component;\n} else {\n\tcomponent(Prism);\n}\n`;
 
@@ -89,6 +92,7 @@ const template = source => `const component = Prism => {\n\t${source.replace(/\n
  *
  * @param {string} source Source code of the component.
  * @returns {string}
+ * @private
  */
 const templateMin = source => `const component=Prism=>{${source}};typeof module!='undefined'&&module.exports?module.exports=component:component(Prism);\n`;
 

--- a/util/dom_utils.js
+++ b/util/dom_utils.js
@@ -61,7 +61,7 @@ const domNextSiblingLeaf = (node, root) => {
  * @param {number} offset Text offset to find node for.
  * @param {Node} root Node to consider the root of the tree.
  * @param {boolean} [nextOnExact=false] Move to the next node if the offset is exactly the length of the current node.
- * @returns {[Node,number]} The node the remaining offset is within.
+ * @returns {{node: Node, offset: number}} The node the remaining offset is within.
  * @private
  */
 const domOffsetNode = (node, offset, root, nextOnExact = false) => {
@@ -69,7 +69,7 @@ const domOffsetNode = (node, offset, root, nextOnExact = false) => {
     if (offset < 0) throw new Error('Negative offset unsupported');
 
     // Short-circuit if we're already at the offset
-    if (offset === 0) return [ node, 0 ];
+    if (offset === 0) return { node, offset: 0 };
 
     // Jump down to the leaf
     let workingNode = node;
@@ -92,7 +92,7 @@ const domOffsetNode = (node, offset, root, nextOnExact = false) => {
         if (workingNode === null) throw new Error('Offset is larger than the document');
     }
 
-    return [ workingNode, workingOffset ];
+    return { node: workingNode, offset: workingOffset };
 };
 
 /**

--- a/util/dom_utils.js
+++ b/util/dom_utils.js
@@ -20,6 +20,7 @@ limitations under the License.
  * Remove all nodes that have no text content recursively, including the given node.
  *
  * @param {Node} node Node to remove empty nodes from (including self).
+ * @private
  */
 const domRemoveEmpty = node => {
     for (const child of [ ...node.childNodes ]) domRemoveEmpty(child);
@@ -33,6 +34,7 @@ const domRemoveEmpty = node => {
  * @param {Node} node Node to find next leaf for.
  * @param {Node} root Node to consider the root of the tree.
  * @returns {?Node}
+ * @private
  */
 const domNextSiblingLeaf = (node, root) => {
     let workingNode = node;
@@ -60,6 +62,7 @@ const domNextSiblingLeaf = (node, root) => {
  * @param {Node} root Node to consider the root of the tree.
  * @param {boolean} [nextOnExact=false] Move to the next node if the offset is exactly the length of the current node.
  * @returns {[Node,number]} The node the remaining offset is within.
+ * @private
  */
 const domOffsetNode = (node, offset, root, nextOnExact = false) => {
     // TODO: Support negative offset with domPreviousSiblingLeaf
@@ -100,6 +103,7 @@ const domOffsetNode = (node, offset, root, nextOnExact = false) => {
  * @param {?number} [offset=null] Optional offset to split at.
  * @param {boolean} [nodeInRight=true] If the node to split on should be in the right tree of the split.
  * @returns {{left: Node[], right: Node[]}}
+ * @private
  */
 const domSplit = (root, node, offset = null, nodeInRight = true) => {
     if (!root.contains(node)) throw new Error('Node is not a child of root');
@@ -170,6 +174,7 @@ const domSplit = (root, node, offset = null, nodeInRight = true) => {
  * @param {Node} node1 First node to consider.
  * @param {Node} node2 Second node to consider.
  * @returns {?Node}
+ * @private
  */
 const domCommonAncestor = (node1, node2) => {
     let parent = node1.parentNode;
@@ -185,6 +190,7 @@ const domCommonAncestor = (node1, node2) => {
  *
  * @param {Node} node Node to consider.
  * @returns {boolean}
+ * @private
  */
 const domNextSiblingsEmpty = node => {
     let workingNode = node;
@@ -200,6 +206,7 @@ const domNextSiblingsEmpty = node => {
  *
  * @param {Node} node Node to consider.
  * @returns {boolean}
+ * @private
  */
 const domPreviousSiblingsEmpty = node => {
     let workingNode = node;

--- a/util/find_attr.js
+++ b/util/find_attr.js
@@ -22,6 +22,7 @@ limitations under the License.
  * @param {string} attr Name of the attribute to find.
  * @param {string} tag HTML opening tag to search within.
  * @returns {?{start: number, end: number}}
+ * @private
  */
 module.exports = (attr, tag) => {
     // Find where attrs start and end

--- a/util/find_tag_open.js
+++ b/util/find_tag_open.js
@@ -22,6 +22,7 @@ limitations under the License.
  * @param {string} tag Name of the tag to find.
  * @param {string} html HTML snippet to search within.
  * @returns {?{start: number, end: number}}
+ * @private
  */
 module.exports = (tag, html) => {
     // Find the start of the tag

--- a/util/prism_keep_html.js
+++ b/util/prism_keep_html.js
@@ -49,6 +49,7 @@ const plugin = Prism => {
      * @property {number} [openPos] Position at which this node opens in the open node.
      * @property {Node} [closeNode] Node in which this node closes, when injecting.
      * @property {number} [closePos] Position at which this node closes in the close node.
+     * @private
      */
 
     /**
@@ -56,6 +57,7 @@ const plugin = Prism => {
      *
      * @param {string} html HTML snippet to extract nodes and text from.
      * @returns {{nodes: ExtractedNode[], text: string}}
+     * @private
      */
     const extractTextAndNodes = html => {
         // Track the plain-text and all the HTML nodes we find
@@ -72,6 +74,7 @@ const plugin = Prism => {
              *
              * @param {string} name Name of the opened tag.
              * @param {Object} attributes Attributes of the opened tag.
+             * @private
              */
             onopentag: (name, attributes) => {
                 // Add the node to the stack
@@ -86,12 +89,15 @@ const plugin = Prism => {
              * Track any plain-text encountered.
              *
              * @param {string} value Plain-text to track.
+             * @private
              */
             ontext: value => {
                 text += value;
             },
             /**
              * Remove the top of the stack when a tag is closed, tracking the close position in the text.
+             *
+             * @private
              */
             onclosetag: () => {
                 // TODO: Compare closed tag name to the top of the stack, error if not equal
@@ -129,6 +135,7 @@ const plugin = Prism => {
      * @param {string} html HTML snippet to parse.
      * @param {ExtractedNode[]} nodes Extracted nodes to inject into the parsed DOM.
      * @returns {string}
+     * @private
      */
     const parseAndInsertNodes = (html, nodes) => {
         // Create an empty DOM
@@ -144,6 +151,7 @@ const plugin = Prism => {
              *
              * @param {string} name Name of the opened tag.
              * @param {Object} attributes Attributes of the opened tag.
+             * @private
              */
             onopentag: (name, attributes) => {
                 const node = document.createElement(name);
@@ -155,6 +163,7 @@ const plugin = Prism => {
              * Add any plain-text encountered to the DOM, updating any nodes to be inserted that fall within this text.
              *
              * @param {string} value Plain-text to add to the DOM.
+             * @private
              */
             ontext: value => {
                 const text = document.createTextNode(value);
@@ -178,6 +187,8 @@ const plugin = Prism => {
             },
             /**
              * Use the parent as the current node we're in when a tag is closed.
+             *
+             * @private
              */
             onclosetag: () => {
                 // TODO: Compare closed tag name to the current node, error if not equal
@@ -237,6 +248,7 @@ const plugin = Prism => {
      *
      * @param {function(string, import('prismjs').Grammar, string): string} original Original highlight function to wrap.
      * @returns {function(string, import('prismjs').Grammar, string): string}
+     * @private
      */
     const highlight = original => (html, grammar, language) => {
         // Extract the plain-text and HTML nodes inside the code block
@@ -254,6 +266,7 @@ const plugin = Prism => {
      * Before Prism begins highlighting, disable the default HTML preservation and use raw HTML for the code.
      *
      * @param {Object} env Current Prism environment.
+     * @private
      */
     const beforeSanityHook = env => {
         // Disable the standard keep-markup plugin
@@ -268,6 +281,7 @@ const plugin = Prism => {
      * After Prism has finished highlighting, remove the class used to disable the default HTML preservation.
      *
      * @param {Object} env Current Prism environment.
+     * @private
      */
     const beforeInsertHook = env => {
         // Remove the no-keep-markup class

--- a/util/prism_keep_html.js
+++ b/util/prism_keep_html.js
@@ -208,14 +208,15 @@ const plugin = Prism => {
 
             // Apply the offset to each and get the ancestor
             // Very loosely equivalent to creating a DOM Level 2 Range
-            const [ openNode, openPos ] = domOffsetNode(node.openNode, node.openPos, root, true);
-            let [ closeNode, closePos ] = domOffsetNode(node.closeNode, node.closePos, root);
+            const { node: openNode, offset: openPos } = domOffsetNode(node.openNode, node.openPos, root, true);
+            let { node: closeNode, offset: closePos } = domOffsetNode(node.closeNode, node.closePos, root);
             let ancestor = domCommonAncestor(openNode, closeNode);
 
             // Split the DOM and get the middle
             // Very loosely equivalent to using DOM Level 2 Range#extractContents
             const splitOpen = domSplit(ancestor, openNode, openPos);
-            [ closeNode, closePos ] = domOffsetNode(closeNode, closePos, root); // Update based on open split
+            const updatedClose = domOffsetNode(closeNode, closePos, root); // Update based on open split
+            closeNode = updatedClose.node; closePos = updatedClose.offset;
             const splitClose = domSplit(ancestor, closeNode, closePos);
             const middle = splitOpen.right.filter(n => splitClose.left.includes(n));
 

--- a/util/prism_keep_html.js
+++ b/util/prism_keep_html.js
@@ -16,6 +16,10 @@ limitations under the License.
 
 'use strict';
 
+/**
+ * @module @digitalocean/do-markdownit/util/prism_keep_html
+ */
+
 const htmlparser2 = require('htmlparser2');
 const slimdom = require('slimdom');
 

--- a/util/prism_keep_html.js
+++ b/util/prism_keep_html.js
@@ -17,7 +17,7 @@ limitations under the License.
 'use strict';
 
 /**
- * @module @digitalocean/do-markdownit/util/prism_keep_html
+ * @module util/prism_keep_html
  */
 
 const htmlparser2 = require('htmlparser2');

--- a/util/prism_keep_html.js
+++ b/util/prism_keep_html.js
@@ -215,8 +215,7 @@ const plugin = Prism => {
             // Split the DOM and get the middle
             // Very loosely equivalent to using DOM Level 2 Range#extractContents
             const splitOpen = domSplit(ancestor, openNode, openPos);
-            const updatedClose = domOffsetNode(closeNode, closePos, root); // Update based on open split
-            closeNode = updatedClose.node; closePos = updatedClose.offset;
+            ({ node: closeNode, offset: closePos } = domOffsetNode(closeNode, closePos, root)); // Update based on open split
             const splitClose = domSplit(ancestor, closeNode, closePos);
             const middle = splitOpen.right.filter(n => splitClose.left.includes(n));
 

--- a/util/safe_object.js
+++ b/util/safe_object.js
@@ -21,6 +21,7 @@ limitations under the License.
  *
  * @param {*} obj Value to check.
  * @returns {boolean}
+ * @private
  */
 const isObject = obj => obj && typeof obj === 'object' && Object.prototype.toString.call(obj) === '[object Object]';
 
@@ -29,6 +30,7 @@ const isObject = obj => obj && typeof obj === 'object' && Object.prototype.toStr
  *
  * @param {Object} original Object to clone.
  * @returns {Object}
+ * @private
  */
 const clone = original => Object.entries(original).reduce((target, [ key, value ]) => ({
     ...target,
@@ -40,5 +42,6 @@ const clone = original => Object.entries(original).reduce((target, [ key, value 
  *
  * @param {*} original Object to clone, if an Object.
  * @returns {Object}
+ * @private
  */
 module.exports = original => (isObject(original) ? clone(original) : ({}));


### PR DESCRIPTION
## Type of Change

- **Something else:** Docs

## What issue does this relate to?

N/A

### What should this PR do?

Some tweaks to how we're documenting things in jsdoc, just to make it more correct for what jsdoc seems to actually expect.

This marks everything we don't expect folks to use as private, and actively indicates what can be used via modules. This is still not perfect, as the index module is given the full module name, but relative modules need just relative names for `jsdoc-tsimport-plugin` to be able to resolve them correctly.

This also introduces the jsdoc CLI as an actual development dependency, so that folks can generate it locally if they desire to check that jsdoc is valid etc. (beyond what the eslint rules check).

### What are the acceptance criteria?

jsdoc can be generated for the project and appears accurate (ish).