### PR TITLE
CanIUse embeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Add support for embedding CanIUse data
 - (minor) Add support for embedding Glitch projects
 
 

--- a/README.md
+++ b/README.md
@@ -192,6 +192,36 @@ Set this property to `false` to disable this plugin.
 
 - `className` (`string`, optional, defaults to `'rsvp'`): Class to use for the button.
 
+### terminal_button
+
+Add support for terminal buttons in Markdown, as block syntax.
+
+The basic syntax is `[terminal <image name>]`. E.g. `[terminal ubuntu:focal]`.
+An optional button title can be provided after the image name. E.g. `[terminal ubuntu:focal Start Terminal]`.
+
+The buttons are disabled by default and do not have any event listeners.
+Once rendered, you should bind your own event listeners and enable the buttons.
+
+You can find all the buttons in the DOM by looking for the `data-js` attribute being set to `terminal`.
+The image name will be set as the `data-docker-image` attribute.
+
+**Example Markdown input:**
+
+    [terminal ubuntu:focal button title]
+
+**Example HTML output:**
+
+    <button data-js="terminal" data-docker-image="ubuntu:focal" disabled="disabled" class="terminal">
+        button title
+    </button>
+
+**Options:**
+
+Pass options for this plugin as the `terminal_button` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+
 ### glob
 
 Add support for [glob](https://www.digitalocean.com/community/tools/glob) embeds in Markdown, as block syntax.
@@ -373,6 +403,50 @@ Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
 
+### caniuse
+
+Add support for [CanIUse](https://caniuse.com/) embeds in Markdown, as block syntax.
+Uses https://caniuse.bitsofco.de/ to provide interactive embeds from CanIUse data.
+
+The basic syntax is `[caniuse <feature>]`. E.g. `[caniuse css-grid]`.
+After the slug, some space-separated flags can be added (in any combination/order):
+
+- Add `past=` followed by a number to control how many previous browser versions to include (default is 1, supported 0-5).
+- Add `future=` followed by a number to control how many previous browser versions to include (default is 1, supported 0-3).
+- Add `accessible` to set the default color scheme for the CanIUse embed to be accessible colors.
+
+**Example Markdown input:**
+
+    [caniuse css-grid]
+
+    [caniuse css-grid past=5 future=3 accessible]
+
+**Example HTML output:**
+
+    <p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1" data-accessible-colours="false">
+        <picture>
+            <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+            <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+            <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+        </picture>
+    </p>
+
+    <p class="ciu_embed" data-periods="future_3,future_2,future_1,current,past_1,past_2,past_3,past_4,past_5" data-accessible-colours="true">
+        <picture>
+            <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/ambient-light.webp" />
+            <source type="image/png" srcset="https://caniuse.bitsofco.de/image/ambient-light.png" />
+            <img src="https://caniuse.bitsofco.de/image/ambient-light.jpg" alt="Data on support for the ambient-light feature across the major browsers from caniuse.com" />
+        </picture>
+    </p>
+    <script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+
+**Options:**
+
+Pass options for this plugin as the `caniuse` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+
 ### youtube
 
 Add support for [YouTube](http://youtube.com/) embeds in Markdown, as block syntax.
@@ -394,36 +468,6 @@ The default value for height is 270, and for width is 480.
 **Options:**
 
 Pass options for this plugin as the `youtube` property of the `do-markdownit` plugin options.
-Set this property to `false` to disable this plugin.
-
-_No options are available for this plugin._
-
-### terminal_button
-
-Add support for terminal buttons in Markdown, as block syntax.
-
-The basic syntax is `[terminal <image name>]`. E.g. `[terminal ubuntu:focal]`.
-An optional button title can be provided after the image name. E.g. `[terminal ubuntu:focal Start Terminal]`.
-
-The buttons are disabled by default and do not have any event listeners.
-Once rendered, you should bind your own event listeners and enable the buttons.
-
-You can find all the buttons in the DOM by looking for the `data-js` attribute being set to `terminal`.
-The image name will be set as the `data-docker-image` attribute.
-
-**Example Markdown input:**
-
-    [terminal ubuntu:focal button title]
-
-**Example HTML output:**
-
-    <button data-js="terminal" data-docker-image="ubuntu:focal" disabled="disabled" class="terminal">
-        button title
-    </button>
-
-**Options:**
-
-Pass options for this plugin as the `terminal_button` property of the `do-markdownit` plugin options.
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -276,6 +276,24 @@ Removing the author attribution from the Glitch embed:
 
 [glitch hello-digitalocean noattr]
 
+### Can I Use
+
+Embedding usage information from Can I Use (feature slug, flags...):
+
+[caniuse css-grid]
+
+Control how many previous browser versions are listed (0-5):
+
+[caniuse css-grid past=5]
+
+Control how many future browser versions are listed (0-3):
+
+[caniuse css-grid future=3]
+
+Enable the accessible color scheme by default:
+
+[caniuse css-grid accessible]
+
 ### Asciinema
 
 Embedding a terminal recording from Asciinema:

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -297,6 +297,39 @@ Please refer to our style and formatting guidelines for more detailed explanatio
         <a href="https://glitch.com/edit/#!/hello-digitalocean" target="_blank">View hello-digitalocean on Glitch</a>
     </iframe>
 </div>
+<h3 id="can-i-use">Can I Use</h3>
+<p>Embedding usage information from Can I Use (feature slug, flags…):</p>
+<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<p>Control how many previous browser versions are listed (0-5):</p>
+<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1,past_2,past_3,past_4,past_5" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<p>Control how many future browser versions are listed (0-3):</p>
+<p class="ciu_embed" data-feature="css-grid" data-periods="future_3,future_2,future_1,current,past_1" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<p>Enable the accessible color scheme by default:</p>
+<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1" data-accessible-colours="true">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
 <h3 id="asciinema">Asciinema</h3>
 <p>Embedding a terminal recording from Asciinema:</p>
 <script src="https://asciinema.org/a/239367.js" id="asciicast-239367" async data-cols="80" data-rows="24"></script>
@@ -320,3 +353,4 @@ These may not be enabled in all contexts in the DigitalOcean community, but are 
 <script async defer src="https://do-community.github.io/glob-tool-embed/bundle.js" type="text/javascript" onload="window.GlobToolEmbeds()"></script>
 <script async defer src="https://do-community.github.io/dns-tool-embed/bundle.js" type="text/javascript" onload="window.DNSToolEmbeds()"></script>
 <script async defer src="https://static.codepen.io/assets/embed/ei.js" type="text/javascript"></script>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>

--- a/index.js
+++ b/index.js
@@ -29,13 +29,14 @@ const safeObject = require('./util/safe_object');
  * @property {false|import('./rules/html_comment').HtmlCommentOptions} [html_comment] Disable HTML comment stripping, or set options for the feature.
  * @property {false|import('./rules/embeds/callout').CalloutOptions} [callout] Disable callout block syntax, or set options for the feature.
  * @property {false|import('./rules/embeds/rsvp_button').RsvpButtonOptions} [rsvp_button] Disable RSVP buttons, or set options for the feature.
+ * @property {false|import('./rules/embeds/terminal_button').TerminalButtonOptions} [terminal_button] Disable terminal buttons, or set options for the feature.
  * @property {false} [glob] Disable glob embeds.
  * @property {false} [dns] Disable DNS lookup embeds.
  * @property {false} [asciinema] Disable Asciinema embeds.
  * @property {false} [codepen] Disable CodePen embeds.
  * @property {false} [glitch] Disable Glitch embeds.
+ * @property {false} [caniuse] Disable CanIUse embeds.
  * @property {false} [youtube] Disable YouTube embeds.
- * @property {false|import('./rules/embeds/terminal_button').TerminalButtonOptions} [terminal_button] Disable terminal buttons, or set options for the feature.
  * @property {false|import('./modifiers/fence_label').FenceLabelOptions} [fence_label] Disable fence labels, or set options for the feature.
  * @property {false|import('./modifiers/fence_secondary_label').FenceSecondaryLabelOptions} [fence_secondary_label] Disable fence secondary labels, or set options for the feature.
  * @property {false|import('./modifiers/fence_environment').FenceEnvironmentOptions} [fence_environment] Disable fence environments, or set options for the feature.
@@ -79,6 +80,10 @@ module.exports = (md, options) => {
         md.use(require('./rules/embeds/rsvp_button'), safeObject(optsObj.rsvp_button));
     }
 
+    if (optsObj.terminal_button !== false) {
+        md.use(require('./rules/embeds/terminal_button'), safeObject(optsObj.terminal_button));
+    }
+
     if (optsObj.glob !== false) {
         md.use(require('./rules/embeds/glob'), safeObject(optsObj.glob));
     }
@@ -99,12 +104,12 @@ module.exports = (md, options) => {
         md.use(require('./rules/embeds/glitch'), safeObject(optsObj.glitch));
     }
 
-    if (optsObj.youtube !== false) {
-        md.use(require('./rules/embeds/youtube'), safeObject(optsObj.youtube));
+    if (optsObj.caniuse !== false) {
+        md.use(require('./rules/embeds/caniuse'), safeObject(optsObj.caniuse));
     }
 
-    if (optsObj.terminal_button !== false) {
-        md.use(require('./rules/embeds/terminal_button'), safeObject(optsObj.terminal_button));
+    if (optsObj.youtube !== false) {
+        md.use(require('./rules/embeds/youtube'), safeObject(optsObj.youtube));
     }
 
     // Register modifiers

--- a/rules/embeds/caniuse.js
+++ b/rules/embeds/caniuse.js
@@ -149,7 +149,7 @@ module.exports = md => {
         const token = tokens[index];
 
         // Construct the attrs
-        const attrPeriodsFuture = Array(token.caniuse.future).fill('').map((_, i) => `future_${i + 1}`);
+        const attrPeriodsFuture = Array(token.caniuse.future).fill('').map((_, i) => `future_${i + 1}`).reverse();
         const attrPeriodsPast = Array(token.caniuse.past).fill('').map((_, i) => `past_${i + 1}`);
         const attrPeriods = md.utils.escapeHtml([ ...attrPeriodsFuture, 'current', ...attrPeriodsPast ].join(','));
         const attrAccessibleColours = md.utils.escapeHtml(token.caniuse.accessible.toString());

--- a/rules/embeds/caniuse.js
+++ b/rules/embeds/caniuse.js
@@ -1,0 +1,170 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module rules/embeds/caniuse
+ */
+
+const safeObject = require('../../util/safe_object');
+/**
+ * Add support for [CanIUse](https://caniuse.com/) embeds in Markdown, as block syntax.
+ * Uses https://caniuse.bitsofco.de/ to provide interactive embeds from CanIUse data.
+ *
+ * The basic syntax is `[caniuse <feature>]`. E.g. `[caniuse css-grid]`.
+ * After the slug, some space-separated flags can be added (in any combination/order):
+ *
+ * - Add `past=` followed by a number to control how many previous browser versions to include (default is 1, supported 0-5).
+ * - Add `future=` followed by a number to control how many previous browser versions to include (default is 1, supported 0-3).
+ * - Add `accessible` to set the default color scheme for the CanIUse embed to be accessible colors.
+ *
+ * @example
+ * [caniuse css-grid]
+ *
+ * [caniuse css-grid past=5 future=3 accessible]
+ *
+ * <p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1" data-accessible-colours="false">
+ *     <picture>
+ *         <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+ *         <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+ *         <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+ *     </picture>
+ * </p>
+ *
+ * <p class="ciu_embed" data-periods="future_3,future_2,future_1,current,past_1,past_2,past_3,past_4,past_5" data-accessible-colours="true">
+ *     <picture>
+ *         <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/ambient-light.webp" />
+ *         <source type="image/png" srcset="https://caniuse.bitsofco.de/image/ambient-light.png" />
+ *         <img src="https://caniuse.bitsofco.de/image/ambient-light.jpg" alt="Data on support for the ambient-light feature across the major browsers from caniuse.com" />
+ *     </picture>
+ * </p>
+ * <script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+ *
+ * @type {import('markdown-it').PluginSimple}
+ */
+module.exports = md => {
+    /**
+     * Parsing rule for CanIUse markup.
+     *
+     * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
+     */
+    const canIUseRule = (state, startLine, endLine, silent) => {
+        // If silent, don't replace
+        if (silent) return false;
+
+        // Get current string to consider (just current line)
+        const pos = state.bMarks[startLine] + state.tShift[startLine];
+        const max = state.eMarks[startLine];
+        const currentLine = state.src.substring(pos, max);
+
+        // Perform some non-regex checks for speed
+        if (currentLine.length < 11) return false; // [caniuse a]
+        if (currentLine.slice(0, 9) !== '[caniuse ') return false;
+        if (currentLine[currentLine.length - 1] !== ']') return false;
+
+        // Check for glitch match
+        const match = currentLine.match(/^\[caniuse (\S+)((?: (?:past=[0-5]|future=[0-3]|accessible))*)\]$/);
+        if (!match) return false;
+
+        // Get the slug
+        const slug = match[1];
+        if (!slug) return false;
+
+        // Get the raw flags
+        const flags = match[2].split(' ');
+
+        // Get the past count
+        const pastMatch = flags.find(flag => flag.match(/^past=[0-5]$/));
+        const past = !pastMatch || Number.isNaN(Number(pastMatch.slice(5))) ? 1 : Number(pastMatch.slice(5));
+
+        // Get the past count
+        const futureMatch = flags.find(flag => flag.match(/^future=[0-3]$/));
+        const future = !futureMatch || Number.isNaN(Number(futureMatch.slice(7))) ? 1 : Number(futureMatch.slice(7));
+
+        // Defines if the embed should be accessible
+        const accessible = flags.includes('accessible');
+
+        // Update the pos for the parser
+        state.line = startLine + 1;
+
+        // Add token to state
+        const token = state.push('caniuse', 'caniuse', 0);
+        token.block = true;
+        token.markup = match[0];
+        token.caniuse = { slug, past, future, accessible };
+
+        // Track that we need the script
+        state.env.caniuse = safeObject(state.env.caniuse);
+        state.env.caniuse.tokenized = true;
+
+        // Done
+        return true;
+    };
+
+    md.block.ruler.before('paragraph', 'caniuse', canIUseRule);
+
+    /**
+     * Parsing rule to inject the CanIUse script.
+     *
+     * @type {import('markdown-it').RuleCore}
+     * @private
+     */
+    const canIUseScriptRule = state => {
+        // Check if we need to inject the script
+        if (state.env.caniuse && state.env.caniuse.tokenized && !state.env.caniuse.injected) {
+            // Set that we've injected it
+            state.env.caniuse.injected = true;
+
+            // Inject the token
+            const token = new state.Token('html_block', '', 0);
+            token.content = '<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>\n';
+            state.tokens.push(token);
+        }
+    };
+
+    md.core.ruler.push('caniuse_script', canIUseScriptRule);
+
+    /**
+     * Rendering rule for CanIUse markup.
+     *
+     * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
+     */
+    md.renderer.rules.caniuse = (tokens, index) => {
+        const token = tokens[index];
+
+        // Construct the attrs
+        const attrPeriodsFuture = Array(token.caniuse.future).fill('').map((_, i) => `future_${i + 1}`);
+        const attrPeriodsPast = Array(token.caniuse.past).fill('').map((_, i) => `past_${i + 1}`);
+        const attrPeriods = md.utils.escapeHtml([ ...attrPeriodsFuture, 'current', ...attrPeriodsPast ].join(','));
+        const attrAccessibleColours = md.utils.escapeHtml(token.caniuse.accessible.toString());
+
+        // Escape some HTML
+        const feature = md.utils.escapeHtml(token.caniuse.slug);
+        const featureUrl = encodeURIComponent(token.caniuse.slug);
+
+        // Return the HTML
+        return `<p class="ciu_embed" data-feature="${feature}" data-periods="${attrPeriods}" data-accessible-colours="${attrAccessibleColours}">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/${featureUrl}.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/${featureUrl}.png" />
+        <img src="https://caniuse.bitsofco.de/image/${featureUrl}.jpg" alt="Data on support for the ${feature} feature across the major browsers from caniuse.com" />
+    </picture>
+</p>\n`;
+    };
+};

--- a/rules/embeds/caniuse.test.js
+++ b/rules/embeds/caniuse.test.js
@@ -1,0 +1,143 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const md = require('markdown-it')().use(require('./caniuse'));
+
+it('handles caniuse embeds (not inline)', () => {
+    expect(md.render('[caniuse css-grid]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+`);
+});
+
+it('handles caniuse embeds with no feature (no embed)', () => {
+    expect(md.render('[caniuse ]')).toBe(`<p>[caniuse ]</p>
+`);
+});
+
+it('handles caniuse embeds that are unclosed (no embed)', () => {
+    expect(md.render('[caniuse css-grid')).toBe(`<p>[caniuse css-grid</p>
+`);
+});
+
+it('handles caniuse embeds with a past count', () => {
+    expect(md.render('[caniuse css-grid past=5]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1,past_2,past_3,past_4,past_5" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+`);
+});
+
+it('handles caniuse embeds with a past count that is zero', () => {
+    expect(md.render('[caniuse css-grid past=0]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+`);
+});
+
+it('handles caniuse embeds with a past count that is negative (no embed)', () => {
+    expect(md.render('[caniuse css-grid past=-1]')).toBe(`<p>[caniuse css-grid past=-1]</p>
+`);
+});
+
+it('handles caniuse embeds with a past count that is too large (no embed)', () => {
+    expect(md.render('[caniuse css-grid past=10]')).toBe(`<p>[caniuse css-grid past=10]</p>
+`);
+});
+
+it('handles caniuse embeds with a past count that is not a number (no embed)', () => {
+    expect(md.render('[caniuse css-grid past=test]')).toBe(`<p>[caniuse css-grid past=test]</p>
+`);
+});
+
+it('handles caniuse embeds with a future count', () => {
+    expect(md.render('[caniuse css-grid future=3]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,future_2,future_3,current,past_1" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+`);
+});
+
+it('handles caniuse embeds with a future count that is zero', () => {
+    expect(md.render('[caniuse css-grid future=0]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="current,past_1" data-accessible-colours="false">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+`);
+});
+
+it('handles caniuse embeds with a future count that is negative (no embed)', () => {
+    expect(md.render('[caniuse css-grid future=-1]')).toBe(`<p>[caniuse css-grid future=-1]</p>
+`);
+});
+
+it('handles caniuse embeds with a future count that is too large (no embed)', () => {
+    expect(md.render('[caniuse css-grid future=5]')).toBe(`<p>[caniuse css-grid future=5]</p>
+`);
+});
+
+it('handles caniuse embeds with a future count that is not a number (no embed)', () => {
+    expect(md.render('[caniuse css-grid future=test]')).toBe(`<p>[caniuse css-grid future=test]</p>
+`);
+});
+
+it('handles caniuse embeds with the accessible flag', () => {
+    expect(md.render('[caniuse css-grid accessible]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1" data-accessible-colours="true">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+`);
+});
+
+it('handles caniuse embeds with multiple flags combined (past, accessible, future)', () => {
+    expect(md.render('[caniuse css-grid past=2 accessible future=2]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,future_2,current,past_1,past_2" data-accessible-colours="true">
+    <picture>
+        <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
+        <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
+        <img src="https://caniuse.bitsofco.de/image/css-grid.jpg" alt="Data on support for the css-grid feature across the major browsers from caniuse.com" />
+    </picture>
+</p>
+<script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
+`);
+});

--- a/rules/embeds/caniuse.test.js
+++ b/rules/embeds/caniuse.test.js
@@ -80,7 +80,7 @@ it('handles caniuse embeds with a past count that is not a number (no embed)', (
 });
 
 it('handles caniuse embeds with a future count', () => {
-    expect(md.render('[caniuse css-grid future=3]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,future_2,future_3,current,past_1" data-accessible-colours="false">
+    expect(md.render('[caniuse css-grid future=3]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_3,future_2,future_1,current,past_1" data-accessible-colours="false">
     <picture>
         <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
         <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />
@@ -131,7 +131,7 @@ it('handles caniuse embeds with the accessible flag', () => {
 });
 
 it('handles caniuse embeds with multiple flags combined (past, accessible, future)', () => {
-    expect(md.render('[caniuse css-grid past=2 accessible future=2]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_1,future_2,current,past_1,past_2" data-accessible-colours="true">
+    expect(md.render('[caniuse css-grid past=2 accessible future=2]')).toBe(`<p class="ciu_embed" data-feature="css-grid" data-periods="future_2,future_1,current,past_1,past_2" data-accessible-colours="true">
     <picture>
         <source type="image/webp" srcset="https://caniuse.bitsofco.de/image/css-grid.webp" />
         <source type="image/png" srcset="https://caniuse.bitsofco.de/image/css-grid.png" />


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** embeds/caniuse

## What issue does this relate to?

N/A

### What should this PR do?

Introduces a new block that allows for a feature from CanIUse.com to be embedded into the Markdown content.

(This also moves terminal_button up to be loaded immediately after rsvp_button, before many of the other embeds, for more logical grouping in the source)

### What are the acceptance criteria?

All customisation flags supported by the embed provider are supported in the Markdown syntax correctly. Using the new Markdown syntax results in embeds correctly rendering as you'd expect them to.