### PR TITLE
Provide SCSS styling for Markdown

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 - **Build Scripts:** <!-- Scripts relating to building, testing or CI -->
 - **Markdown-It Plugins:** <!-- Which part of the Markdown-It plugins? -->
+- **SCSS Styling:** <!-- Which part of the SCSS styling? -->
 - **PrismJS Integration:** <!-- Changes relating to PrismJS, the vendoring and HTML plugin -->
 - **Something else:** <!-- Say what it is, here! -->
 

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,6 +1,11 @@
 {
   "extends": "stylelint-config-standard-scss",
   "rules": {
-    "indentation": 4
+    "alpha-value-notation": "number",
+    "color-function-notation": "legacy",
+    "color-hex-length": "long",
+    "indentation": 4,
+    "no-descending-specificity": null,
+    "no-invalid-position-at-import-rule": null
   }
 }

--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,6 @@
+{
+  "extends": "stylelint-config-standard-scss",
+  "rules": {
+    "indentation": 4
+  }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Provide SCSS styling for Markdown
 - (patch) Add development setup using Webpack
 - (minor) Add support for embedding CanIUse data
 - (minor) Add support for embedding Glitch projects

--- a/README.md
+++ b/README.md
@@ -145,11 +145,11 @@ The label cannot contain any newlines, but does support inline Markdown syntax.
 
 **Example HTML output:**
 
-    <div class="info">
+    <div class="callout info">
     <p>test</p>
     </div>
 
-    <div class="info">
+    <div class="callout info">
     <p class="callout-label">hello</p>
     <p>world</p>
     </div>
@@ -160,7 +160,7 @@ Pass options for this plugin as the `callout` property of the `do-markdownit` pl
 Set this property to `false` to disable this plugin.
 
 - `allowedClasses` (`string[]`, optional): List of case-sensitive classes that are allowed. If not an array, all classes are allowed.
-- `extraClasses` (`string[]`, optional, defaults to `[]`): List of extra classes to apply to a callout div, alongside the given class.
+- `extraClasses` (`string[]`, optional, defaults to `['callout']`): List of extra classes to apply to a callout div, alongside the given class.
 - `labelClass` (`string`, optional, defaults to `'callout-label'`): Class to use for the label.
 
 ### rsvp_button

--- a/README.md
+++ b/README.md
@@ -792,6 +792,63 @@ Prism.highlight('console.log("<mark>Hello, world!</mark>");', Prism.languages.ja
 ```
 
 
+## Styles
+
+This package also includes a set of SCSS stylesheets aimed at providing standard styles for our
+usage of Markdown within the DigitalOcean community, styling the features provided by this package
+as well as styling for standard Markdown.
+
+These are broken up by component, and can be found in the [`styles`](./styles) directory. There is
+also a subdirectory within for [DigitalOcean-specific styles](./styles/digitalocean) (e.g. specific
+callout classes that we use).
+
+Example usage:
+
+```scss
+.markdown {
+    @import "@digitalocean/do-markdownit/styles";
+}
+```
+
+Note that if you're planning to use this in a way that will ultimately pass through Webpack's
+css-loader to produce CSS modules (such as Next.js SCSS module), you may need to wrap the import in
+a block using the `:global` pseudo-selector to ensure the classes inside aren't exported as well:
+
+```scss
+.markdown {
+    :global {
+        @import "@digitalocean/do-markdownit/styles";
+    }
+}
+```
+
+If you're importing this as a global style without a parent, you will need to set `$rootTextStyles`
+to `false` to prevent the default text styling that uses a `& {` selector from being loaded:
+
+_Importing the styles globally is not recommended, as these Markdown styles may collide with other
+parts of your document._
+
+```scss
+$rootTextStyles: false;
+@import "@digitalocean/do-markdownit/styles";
+```
+
+### SCSS Variables
+
+| Variable                   | Default                | Usage                                                        | File                                                                |
+|----------------------------|------------------------|--------------------------------------------------------------|---------------------------------------------------------------------|
+| `$calloutsClass`           | `callout`              | The class name used for the `callout` plugin.                | [`_callouts.scss`](./styles/_callouts.scss)                         |
+| `$calloutsLabelClass`      | `callout-label`        | The class name used for labels in the `callout` plugin.      | [`_callouts.scss`](./styles/_callouts.scss)                         |
+| `$codeLabelClass`          | `code-label`           | The class name used for the `fence_label` plugin.            | [`_code_label.scss`](./styles/_code_label.scss)                     |
+| `$codeSecondaryLabelClass` | `secondary-code-label` | The class name used for the `fence_secondary_label` plugin.  | [`_code_secondary_label.scss`](./styles/_code_secondary_label.scss) |
+| `$rsvpButtonClass`         | `rsvp`                 | The class name used for the `rsvp_button` plugin.            | [`_rsvp_button.scss`](./styles/_rsvp_button.scss)                   |
+| `$terminalButtonClass`     | `terminal`             | The class name used for the `terminal_button` plugin.        | [`_terminal_button.scss`](./styles/_terminal_button.scss)           |
+| `$rootTextStyles`          | `true`                 | Enable or disable the `& {` selector for root text styles.   | [`_typography.scss`](./styles/_typography.scss)                     |
+
+Alongside these variables used for controlling specific styles, there is also the
+[`_theme.scss`](./styles/_theme.scss) file that contains all the colors used by the package.
+
+
 ## Contributing
 
 ### Development
@@ -816,6 +873,9 @@ expected. As well as isolated tests, example usage of the plugin should be added
 be loaded in `index.js`).
 
 This repo makes use of Jest to run all the tests, and you can run the full suite with `npm test`.
+
+We also have the `styles` directory, which contains the SCSS files provided by the package to style
+all the custom functionality this plugin provides, as well as core Markdown styles.
 
 We also make use of ESLint to enforce a consistent style of code, as well as checking that JSDoc
 comments are present with valid types and descriptions. You can run the linter with `npm run lint`.

--- a/README.md
+++ b/README.md
@@ -822,28 +822,29 @@ a block using the `:global` pseudo-selector to ensure the classes inside aren't 
 }
 ```
 
-If you're importing this as a global style without a parent, you will need to set `$rootTextStyles`
-to `false` to prevent the default text styling that uses a `& {` selector from being loaded:
+If you're importing this as a context where there will be no parent selector, you will need to set
+`$root-text-styles` to `false` to prevent the default text styling that uses a `& {` selector from
+being loaded:
 
 _Importing the styles globally is not recommended, as these Markdown styles may collide with other
 parts of your document._
 
 ```scss
-$rootTextStyles: false;
+$root-text-styles: false;
 @import "@digitalocean/do-markdownit/styles";
 ```
 
 ### SCSS Variables
 
-| Variable                   | Default                | Usage                                                        | File                                                                |
-|----------------------------|------------------------|--------------------------------------------------------------|---------------------------------------------------------------------|
-| `$calloutsClass`           | `callout`              | The class name used for the `callout` plugin.                | [`_callouts.scss`](./styles/_callouts.scss)                         |
-| `$calloutsLabelClass`      | `callout-label`        | The class name used for labels in the `callout` plugin.      | [`_callouts.scss`](./styles/_callouts.scss)                         |
-| `$codeLabelClass`          | `code-label`           | The class name used for the `fence_label` plugin.            | [`_code_label.scss`](./styles/_code_label.scss)                     |
-| `$codeSecondaryLabelClass` | `secondary-code-label` | The class name used for the `fence_secondary_label` plugin.  | [`_code_secondary_label.scss`](./styles/_code_secondary_label.scss) |
-| `$rsvpButtonClass`         | `rsvp`                 | The class name used for the `rsvp_button` plugin.            | [`_rsvp_button.scss`](./styles/_rsvp_button.scss)                   |
-| `$terminalButtonClass`     | `terminal`             | The class name used for the `terminal_button` plugin.        | [`_terminal_button.scss`](./styles/_terminal_button.scss)           |
-| `$rootTextStyles`          | `true`                 | Enable or disable the `& {` selector for root text styles.   | [`_typography.scss`](./styles/_typography.scss)                     |
+| Variable                      | Default                | Usage                                                       | File                                                                |
+|-------------------------------|------------------------|-------------------------------------------------------------|---------------------------------------------------------------------|
+| `$callouts-class`             | `callout`              | The class name used for the `callout` plugin.               | [`_callouts.scss`](./styles/_callouts.scss)                         |
+| `$callouts-label-class`       | `callout-label`        | The class name used for labels in the `callout` plugin.     | [`_callouts.scss`](./styles/_callouts.scss)                         |
+| `$code-label-class`           | `code-label`           | The class name used for the `fence_label` plugin.           | [`_code_label.scss`](./styles/_code_label.scss)                     |
+| `$code-secondary-label-class` | `secondary-code-label` | The class name used for the `fence_secondary_label` plugin. | [`_code_secondary_label.scss`](./styles/_code_secondary_label.scss) |
+| `$rsvp-button-class`          | `rsvp`                 | The class name used for the `rsvp_button` plugin.           | [`_rsvp_button.scss`](./styles/_rsvp_button.scss)                   |
+| `$terminal-button-class`      | `terminal`             | The class name used for the `terminal_button` plugin.       | [`_terminal_button.scss`](./styles/_terminal_button.scss)           |
+| `$root-text-styles`           | `true`                 | Enable or disable the `& {` selector for root text styles.  | [`_typography.scss`](./styles/_typography.scss)                     |
 
 Alongside these variables used for controlling specific styles, there is also the
 [`_theme.scss`](./styles/_theme.scss) file that contains all the colors used by the package.

--- a/README.md
+++ b/README.md
@@ -858,6 +858,10 @@ To get started working with this repository, clone it locally first. Ensure that
 correct version of Node.js as specified in the `.nvmrc` file, and then install the dependencies
 following the lockfile by running `npm ci`.
 
+You can then start up the demo server by running `npm run dev`. This runs a barebones instance of
+Webpack with hot-reload enabled that provides a real-time input that renders to Markdown, using the
+plugins in this package as well as the SCSS styling.
+
 We have two key directories that contain plugins in this repository -- `modifiers` and `rules`.
 
 The `modifiers` directory contains plugins that modify the output of existing Markdown-It render
@@ -878,8 +882,12 @@ This repo makes use of Jest to run all the tests, and you can run the full suite
 We also have the `styles` directory, which contains the SCSS files provided by the package to style
 all the custom functionality this plugin provides, as well as core Markdown styles.
 
-We also make use of ESLint to enforce a consistent style of code, as well as checking that JSDoc
-comments are present with valid types and descriptions. You can run the linter with `npm run lint`.
+We also make use of ESLint and Stylelint to enforce a consistent style of code, as well as checking
+that JSDoc comments are present with valid types and descriptions. You can run the linter for both
+JS and SCSS with `npm run lint`, or using `npm run lint:js` and `npm run lint:scss` respectively.
+
+Both linters also support auto-fixing some issues, and this can be invoked with `npm run lint:fix`,
+or by using `npm run lint:fix:js` and `npm run lint:fix:scss` for the relevant files.
 
 ### Pull Requests & Issues
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,8 @@ The information under each heading should match the main JSDoc comment for each 
 
 ### highlight
 
-Add support for highlight markup across all Markdown, including inside code.
+<details>
+<summary>Add support for highlight markup across all Markdown, including inside code.</summary>
 
 The syntax for highlighting text is `<^>`. E.g. `<^>hello world<^>`.
 This syntax is treated as regular inline syntax, similar to bold or italics.
@@ -71,10 +72,12 @@ Pass options for this plugin as the `highlight` property of the `do-markdownit` 
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### user_mention
 
-Add support for mentioning users, using an `@` symbol. Wraps the mention in a link to the user.
+<details>
+<summary>Add support for mentioning users, using an `@` symbol. Wraps the mention in a link to the user.</summary>
 
 By default, any characters that are not a space or newline after an `@` symbol will be treated as a mention.
 
@@ -93,10 +96,12 @@ Set this property to `false` to disable this plugin.
 
 - `pattern` (`RexExp`, optional): A pattern to match user mentions, applied to the string after the `@` symbol.
 - `path` (`function(string): string`, optional): A function to get the URL path for a user mention.
+</details>
 
 ### html_comment
 
-Removes all HTML comments from Markdown.
+<details>
+<summary>Removes all HTML comments from Markdown.</summary>
 
 This treats HTML comments as Markdown syntax, so expects them to either be inline, or a full block.
 Comments that start inline and then span a block will not be removed.
@@ -119,10 +124,12 @@ Pass options for this plugin as the `html_comment` property of the `do-markdowni
 Set this property to `false` to disable this plugin.
 
 - `strict` (`boolean`, optional, defaults to `false`): If the end of a comment must be explicitly found.
+</details>
 
 ### callout
 
-Add support for callout embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for callout embeds in Markdown, as block syntax.</summary>
 
 The basic syntax is `<$>[<class>]<text><$>`. E.g. `<$>[hello]world<$>`.
 The class must be in square brackets, and must come immediately after the opening `<$>`.
@@ -162,10 +169,12 @@ Set this property to `false` to disable this plugin.
 - `allowedClasses` (`string[]`, optional): List of case-sensitive classes that are allowed. If not an array, all classes are allowed.
 - `extraClasses` (`string[]`, optional, defaults to `['callout']`): List of extra classes to apply to a callout div, alongside the given class.
 - `labelClass` (`string`, optional, defaults to `'callout-label'`): Class to use for the label.
+</details>
 
 ### rsvp_button
 
-Add support for RSVP buttons in Markdown, as inline syntax.
+<details>
+<summary>Add support for RSVP buttons in Markdown, as inline syntax.</summary>
 
 The basic syntax is `[rsvp_button <marketo id>]`. E.g. `[rsvp_button 12345]`.
 Optionally, a title can be set for the button in double quotes after the id. E.g. `[rsvp_button 12345 "My Button"]`.
@@ -191,10 +200,12 @@ Pass options for this plugin as the `rsvp_button` property of the `do-markdownit
 Set this property to `false` to disable this plugin.
 
 - `className` (`string`, optional, defaults to `'rsvp'`): Class to use for the button.
+</details>
 
 ### terminal_button
 
-Add support for terminal buttons in Markdown, as block syntax.
+<details>
+<summary>Add support for terminal buttons in Markdown, as block syntax.</summary>
 
 The basic syntax is `[terminal <image name>]`. E.g. `[terminal ubuntu:focal]`.
 An optional button title can be provided after the image name. E.g. `[terminal ubuntu:focal Start Terminal]`.
@@ -221,10 +232,12 @@ Pass options for this plugin as the `terminal_button` property of the `do-markdo
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### glob
 
-Add support for [glob](https://www.digitalocean.com/community/tools/glob) embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for <a href="https://www.digitalocean.com/community/tools/glob">glob</a> embeds in Markdown, as block syntax.</summary>
 
 The basic syntax is `[glob <pattern> <strings>]`. E.g. `[glob *.js a.js b.js c.css]`.
 After the pattern, strings can be provided on a single line, or each separated by a newline.
@@ -259,10 +272,12 @@ Pass options for this plugin as the `glob` property of the `do-markdownit` plugi
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### dns
 
-Add support for [DNS lookup](https://www.digitalocean.com/community/tools/dns) embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for <a href="https://www.digitalocean.com/community/tools/dns">DNS lookup</a> embeds in Markdown, as block syntax.</summary>
 
 The basic syntax is `[dns <domain>]`. E.g. `[dns digitalocean.com]`.
 After the domain, one or more space-separated DNS record types can be added. The default type is `A`.
@@ -294,10 +309,12 @@ Pass options for this plugin as the `dns` property of the `do-markdownit` plugin
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### asciinema
 
-Add support for [Asciinema](http://asciinema.org/) embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for <a href="http://asciinema.org/">Asciinema</a> embeds in Markdown, as block syntax.</summary>
 
 The basic syntax is `[asciinema <id>]`. E.g. `[asciinema 325730]`.
 The cols and rows can optionally be set using `[asciinema <id> [cols] [rows]]`. E.g. `[asciinema 325730 100 50]`.
@@ -320,10 +337,12 @@ Pass options for this plugin as the `asciinema` property of the `do-markdownit` 
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### codepen
 
-Add support for [CodePen](https://codepen.io/) embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for <a href="https://codepen.io/">CodePen</a> embeds in Markdown, as block syntax.</summary>
 
 The basic syntax is `[codepen <user> <hash>]`. E.g. `[codepen AlbertFeynman gjpgjN]`.
 After the user and hash, assorted space-separated flags can be added (in any combination/order):
@@ -361,10 +380,12 @@ Pass options for this plugin as the `codepen` property of the `do-markdownit` pl
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### glitch
 
-Add support for [Glitch](https://glitch.com/) embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for <a href="https://glitch.com/">Glitch</a> embeds in Markdown, as block syntax.</summary>
 
 The basic syntax is `[glitch <slug>]`. E.g. `[glitch hello-digitalocean]`.
 After the slug, some space-separated flags can be added (in any combination/order):
@@ -402,10 +423,13 @@ Pass options for this plugin as the `glitch` property of the `do-markdownit` plu
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### caniuse
 
-Add support for [CanIUse](https://caniuse.com/) embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for <a href="https://caniuse.com/">CanIUse</a> embeds in Markdown, as block syntax.</summary>
+
 Uses https://caniuse.bitsofco.de/ to provide interactive embeds from CanIUse data.
 
 The basic syntax is `[caniuse <feature>]`. E.g. `[caniuse css-grid]`.
@@ -446,10 +470,12 @@ Pass options for this plugin as the `caniuse` property of the `do-markdownit` pl
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### youtube
 
-Add support for [YouTube](http://youtube.com/) embeds in Markdown, as block syntax.
+<details>
+<summary>Add support for <a href="http://youtube.com/">YouTube</a> embeds in Markdown, as block syntax.</summary>
 
 The basic syntax is `[youtube <id>]`. E.g. `[youtube iom_nhYQIYk]`.
 Height and width can optionally be set using `[youtube <id> [height] [width]]`. E.g. `[youtube iom_nhYQIYk 380 560]`.
@@ -471,10 +497,12 @@ Pass options for this plugin as the `youtube` property of the `do-markdownit` pl
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### fence_label
 
-Add support for label markup at the start of a fence, translating to a label div before the fence.
+<details>
+<summary>Add support for label markup at the start of a fence, translating to a label div before the fence.</summary>
 
 Markup must be at the start of the fence, though may be preceded by other metadata markup using square brackets.
 
@@ -499,10 +527,12 @@ Pass options for this plugin as the `fence_label` property of the `do-markdownit
 Set this property to `false` to disable this plugin.
 
 - `className` (`string`, optional, defaults to `'code-label'`): Class name to use on the label div.
+</details>
 
 ### fence_secondary_label
 
-Add support for secondary label markup at the start of a fence, translating to a label div inside the fence.
+<details>
+<summary>Add support for secondary label markup at the start of a fence, translating to a label div inside the fence.</summary>
 
 Markup must be at the start of the fence, though may be preceded by other metadata markup using square brackets.
 
@@ -526,10 +556,12 @@ Pass options for this plugin as the `fence_secondary_label` property of the `do-
 Set this property to `false` to disable this plugin.
 
 - `className` (`string`, optional, defaults to `'secondary-code-label'`): Class name to use on the label div.
+</details>
 
 ### fence_environment
 
-Add support for environment markup at the start of a fence, translating to a class.
+<details>
+<summary>Add support for environment markup at the start of a fence, translating to a class.</summary>
 
 Markup must be at the start of the fence, though may be preceded by other metadata markup using square brackets.
 
@@ -554,10 +586,12 @@ Set this property to `false` to disable this plugin.
 
 - `allowedEnvironments` (`string[]`, optional): List of case-sensitive environments that are allowed. If not an array, all environments are allowed.
 - `extraClasses` (`string`, optional, defaults to `''`): String of extra classes to set when an environment is used.
+</details>
 
 ### fence_prefix
 
-Add support for a prefix to be set for each line on a fenced code block.
+<details>
+<summary>Add support for a prefix to be set for each line on a fenced code block.</summary>
 
 The prefix is set as part of the 'info' provided immediately after the opening fence.
 
@@ -598,10 +632,12 @@ Pass options for this plugin as the `fence_prefix` property of the `do-markdowni
 Set this property to `false` to disable this plugin.
 
 - `delimiter` (`string`, optional, defaults to `','`): String to split fence information on.
+</details>
 
 ### fence_pre_attrs
 
-Move all attributes from the opening `code` tag of a fenced code block to the `pre` tag.
+<details>
+<summary>Move all attributes from the opening `code` tag of a fenced code block to the `pre` tag.</summary>
 
 **Example Markdown input:**
 
@@ -622,10 +658,12 @@ Pass options for this plugin as the `fence_pre_attrs` property of the `do-markdo
 Set this property to `false` to disable this plugin.
 
 _No options are available for this plugin._
+</details>
 
 ### fence_classes
 
-Filters classes on code and pre tags in fences.
+<details>
+<summary>Filters classes on code and pre tags in fences.</summary>
 
 **Example Markdown input:**
 
@@ -655,10 +693,12 @@ Pass options for this plugin as the `fence_classes` property of the `do-markdown
 Set this property to `false` to disable this plugin.
 
 - `allowedClasses` (`string[]`, optional): List of case-sensitive classes that are allowed. If not an array, all classes are allowed.
+</details>
 
 ### heading_id
 
-Apply Ids to all rendered headings and generate an array of headings.
+<details>
+<summary>Apply Ids to all rendered headings and generate an array of headings.</summary>
 
 Headings are available after a render via `md.headings`.
 Each item in the array is an object with the following properties:
@@ -682,10 +722,12 @@ Pass options for this plugin as the `heading_id` property of the `do-markdownit`
 Set this property to `false` to disable this plugin.
 
 - `sluggify` (`function(string): string`, optional): Custom function to convert heading content to a slug Id.
+</details>
 
 ### prismjs
 
-Apply PrismJS syntax highlighting to fenced code blocks, based on the language set in the fence info.
+<details>
+<summary>Apply PrismJS syntax highlighting to fenced code blocks, based on the language set in the fence info.</summary>
 
 This loads a custom PrismJS plugin to ensure that any existing HTML markup inside the code block is preserved.
 This plugin is similar to the default `keep-markup` plugin, but works in a non-browser environment.
@@ -711,6 +753,7 @@ Pass options for this plugin as the `prismjs` property of the `do-markdownit` pl
 Set this property to `false` to disable this plugin.
 
 - `delimiter` (`string`, optional, defaults to `','`): String to split fence information on.
+</details>
 
 
 ## PrismJS

--- a/dev/client.html
+++ b/dev/client.html
@@ -20,43 +20,7 @@ limitations under the License.
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0" />
     <title>do-markdownit</title>
     <style>
-        html,
-        body {
-            padding: 0;
-            margin: 0;
-        }
 
-        #app {
-            display: flex;
-            flex-direction: column;
-        }
-
-        #textbox,
-        #output {
-            padding: 1rem;
-            margin: 0;
-        }
-
-        #textbox {
-            border: none;
-            background: rgba(0, 0, 0, 0.05);
-        }
-
-        #output {
-            overflow: auto;
-        }
-
-        @media only screen and (min-width: 768px) {
-            #app {
-                display: flex;
-                flex-flow: row nowrap;
-            }
-
-            #textbox,
-            #output {
-                flex-basis: 50%;
-            }
-        }
     </style>
 </head>
 <body>

--- a/dev/client.html
+++ b/dev/client.html
@@ -19,9 +19,6 @@ limitations under the License.
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, height=device-height, initial-scale=1.0, minimum-scale=1.0" />
     <title>do-markdownit</title>
-    <style>
-
-    </style>
 </head>
 <body>
 <div id="app">

--- a/dev/client.js
+++ b/dev/client.js
@@ -16,6 +16,7 @@ limitations under the License.
 
 'use strict';
 
+require('./client.scss');
 const render = require('./render');
 
 document.addEventListener('DOMContentLoaded', () => {

--- a/dev/client.scss
+++ b/dev/client.scss
@@ -1,0 +1,40 @@
+html,
+body {
+    padding: 0;
+    margin: 0;
+}
+
+#app {
+    display: flex;
+    flex-direction: column;
+}
+
+#textbox,
+#output {
+    padding: 1rem;
+    margin: 0;
+}
+
+#textbox {
+    border: none;
+    background: rgba(0, 0, 0, 0.025);
+}
+
+#output {
+    @import '../styles';
+    @import '../styles/digitalocean';
+
+    overflow: auto;
+}
+
+@media only screen and (min-width: 768px) {
+    #app {
+        display: flex;
+        flex-flow: row nowrap;
+    }
+
+    #textbox,
+    #output {
+        flex-basis: 50%;
+    }
+}

--- a/dev/client.scss
+++ b/dev/client.scss
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 html,
 body {
     padding: 0;

--- a/dev/client.scss
+++ b/dev/client.scss
@@ -37,8 +37,8 @@ body {
 }
 
 #output {
-    @import '../styles';
-    @import '../styles/digitalocean';
+    @import "../styles";
+    @import "../styles/digitalocean";
 
     overflow: auto;
 }

--- a/dev/client.scss
+++ b/dev/client.scss
@@ -21,8 +21,8 @@ body {
 }
 
 #app {
-    display: flex;
-    flex-direction: column;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(384px, 1fr));
 }
 
 #textbox,
@@ -41,16 +41,4 @@ body {
     @import "../styles/digitalocean";
 
     overflow: auto;
-}
-
-@media only screen and (min-width: 768px) {
-    #app {
-        display: flex;
-        flex-flow: row nowrap;
-    }
-
-    #textbox,
-    #output {
-        flex-basis: 50%;
-    }
 }

--- a/dev/webpack.config.js
+++ b/dev/webpack.config.js
@@ -39,4 +39,16 @@ module.exports = {
             },
         }),
     ],
+    module: {
+        rules: [
+            {
+                test: /\.s[ac]ss$/i,
+                use: [
+                    'style-loader',
+                    'css-loader',
+                    'sass-loader',
+                ],
+            },
+        ],
+    },
 };

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -186,20 +186,20 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 </code></pre>
 <h2 id="step-3-callouts">Step 3 — Callouts</h2>
 <p>Here is a note, a warning, some info and a draft note:</p>
-<div class="note">
+<div class="callout note">
 <p><strong>Note:</strong> Use this for notes on a publication.</p>
 </div>
-<div class="warning">
+<div class="callout warning">
 <p><strong>Warning:</strong> Use this to warn users.</p>
 </div>
-<div class="info">
+<div class="callout info">
 <p><strong>Info:</strong> Use this for product information.</p>
 </div>
-<div class="draft">
+<div class="callout draft">
 <p><strong>Draft:</strong> Use this for notes in a draft publication.</p>
 </div>
 <p>A callout can also be given a label, which supports inline markdown as well:</p>
-<div class="note">
+<div class="callout note">
 <p class="callout-label">Labels support <em>inline</em> <strong>markdown</strong></p>
 <p><strong>Note:</strong> Use this for notes on a publication.</p>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
         "sass": "^1.52.3",
         "sass-loader": "^13.0.0",
         "style-loader": "^3.3.1",
+        "stylelint": "^14.9.1",
+        "stylelint-config-standard-scss": "^4.0.0",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.9.2"
@@ -606,6 +608,23 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "node_modules/@csstools/selector-specificity": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz",
+      "integrity": "sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==",
+      "dev": true,
+      "engines": {
+        "node": "^12 || ^14 || >=16"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/csstools"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3",
+        "postcss-selector-parser": "^6.0.10"
+      }
+    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -1029,6 +1048,41 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -1272,10 +1326,28 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "node_modules/@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
     "node_modules/@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true
+    },
+    "node_modules/@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -1817,6 +1889,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/array.prototype.flat": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
@@ -1832,6 +1913,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/asynckit": {
@@ -2141,6 +2240,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001312",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
@@ -2285,6 +2401,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+      "dev": true,
+      "dependencies": {
+        "is-regexp": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -2317,6 +2445,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
       "dev": true
     },
     "node_modules/colorette": {
@@ -2489,6 +2623,22 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
+    "node_modules/cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2501,6 +2651,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/css-functions-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+      "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.22"
       }
     },
     "node_modules/css-loader": {
@@ -2639,6 +2798,37 @@
         }
       }
     },
+    "node_modules/decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "dev": true,
+      "dependencies": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/decamelize-keys/node_modules/map-obj": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+      "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/decimal.js": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -2749,6 +2939,18 @@
       "dev": true,
       "engines": {
         "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "dependencies": {
+        "path-type": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dns-equal": {
@@ -3566,6 +3768,18 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/execall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+      "dev": true,
+      "dependencies": {
+        "clone-regexp": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -3679,6 +3893,34 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "node_modules/fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fast-glob/node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -3696,6 +3938,15 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
+    },
+    "node_modules/fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
@@ -3938,6 +4189,18 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -4004,6 +4267,44 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
+    "node_modules/global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "dependencies": {
+        "global-prefix": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "dependencies": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
     "node_modules/globals": {
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
@@ -4019,6 +4320,32 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "dependencies": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.9",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.9.tgz",
@@ -4030,6 +4357,15 @@
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
       "dev": true
+    },
+    "node_modules/hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/has": {
       "version": "1.0.3",
@@ -4095,6 +4431,18 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/hpack.js": {
@@ -4185,6 +4533,18 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/html-tags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+      "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/html-webpack-plugin": {
@@ -4396,6 +4756,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -4424,6 +4793,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -4438,6 +4816,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "node_modules/internal-slot": {
@@ -4691,6 +5075,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/is-shared-array-buffer": {
@@ -5687,6 +6080,12 @@
         "node": ">= 8"
       }
     },
+    "node_modules/known-css-properties": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
+      "integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
+      "dev": true
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5757,6 +6156,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "node_modules/lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true
+    },
     "node_modules/lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -5802,6 +6207,18 @@
         "tmpl": "1.0.5"
       }
     },
+    "node_modules/map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/markdown-it": {
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
@@ -5840,6 +6257,16 @@
         "node": ">= 12"
       }
     },
+    "node_modules/mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -5867,6 +6294,44 @@
         "node": ">= 4.0.0"
       }
     },
+    "node_modules/meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/meow/node_modules/type-fest": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+      "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -5879,6 +6344,15 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -5889,13 +6363,13 @@
       }
     },
     "node_modules/micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "dependencies": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       },
       "engines": {
         "node": ">=8.6"
@@ -5943,6 +6417,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -5966,6 +6449,29 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "node_modules/minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "dependencies": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/minimist-options/node_modules/is-plain-obj": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+      "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/mkdirp": {
       "version": "1.0.4",
@@ -6061,6 +6567,36 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
       "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
       "dev": true
+    },
+    "node_modules/normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/normalize-package-data/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",
@@ -6406,6 +6942,15 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -6469,6 +7014,12 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true
+    },
     "node_modules/postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
@@ -6526,6 +7077,44 @@
       },
       "peerDependencies": {
         "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
+      "dev": true
+    },
+    "node_modules/postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
+      }
+    },
+    "node_modules/postcss-scss": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+      "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
+      },
+      "peerDependencies": {
+        "postcss": "^8.3.3"
       }
     },
     "node_modules/postcss-selector-parser": {
@@ -6671,6 +7260,35 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -6719,6 +7337,83 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "node_modules/read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "dependencies": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "dependencies": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/read-pkg-up/node_modules/type-fest": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+      "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/read-pkg/node_modules/hosted-git-info": {
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+      "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+      "dev": true
+    },
+    "node_modules/read-pkg/node_modules/normalize-package-data": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+      "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^2.1.4",
+        "resolve": "^1.10.0",
+        "semver": "2 || 3 || 4 || 5",
+        "validate-npm-package-license": "^3.0.1"
+      }
+    },
+    "node_modules/read-pkg/node_modules/semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
+      }
+    },
+    "node_modules/read-pkg/node_modules/type-fest": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -6755,6 +7450,19 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/regexpp": {
@@ -6917,6 +7625,16 @@
         "node": ">= 4"
       }
     },
+    "node_modules/reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true,
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -6930,6 +7648,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -7277,6 +8018,23 @@
         "node": ">=8"
       }
     },
+    "node_modules/slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
     "node_modules/slimdom": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/slimdom/-/slimdom-3.1.0.tgz",
@@ -7319,6 +8077,16 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "dependencies": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "node_modules/spdx-exceptions": {
@@ -7512,6 +8280,18 @@
         "node": ">=6"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -7538,6 +8318,171 @@
       },
       "peerDependencies": {
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true
+    },
+    "node_modules/stylelint": {
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.9.1.tgz",
+      "integrity": "sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/selector-specificity": "^2.0.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
+        "cosmiconfig": "^7.0.1",
+        "css-functions-list": "^3.1.0",
+        "debug": "^4.3.4",
+        "execall": "^2.0.0",
+        "fast-glob": "^3.2.11",
+        "fastest-levenshtein": "^1.0.12",
+        "file-entry-cache": "^6.0.1",
+        "get-stdin": "^8.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.2.0",
+        "ignore": "^5.2.0",
+        "import-lazy": "^4.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.25.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^9.0.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "style-search": "^0.1.0",
+        "supports-hyperlinks": "^2.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.8.0",
+        "v8-compile-cache": "^2.3.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "bin": {
+        "stylelint": "bin/stylelint.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/stylelint"
+      }
+    },
+    "node_modules/stylelint-config-recommended": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+      "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
+      "dev": true,
+      "peerDependencies": {
+        "stylelint": "^14.4.0"
+      }
+    },
+    "node_modules/stylelint-config-recommended-scss": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-6.0.0.tgz",
+      "integrity": "sha512-6QOe2/OzXV2AP5FE12A7+qtKdZik7Saf42SMMl84ksVBBPpTdrV+9HaCbPYiRMiwELY9hXCVdH4wlJ+YJb5eig==",
+      "dev": true,
+      "dependencies": {
+        "postcss-scss": "^4.0.2",
+        "stylelint-config-recommended": "^7.0.0",
+        "stylelint-scss": "^4.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.4.0"
+      }
+    },
+    "node_modules/stylelint-config-standard": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-25.0.0.tgz",
+      "integrity": "sha512-21HnP3VSpaT1wFjFvv9VjvOGDtAviv47uTp3uFmzcN+3Lt+RYRv6oAplLaV51Kf792JSxJ6svCJh/G18E9VnCA==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended": "^7.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.4.0"
+      }
+    },
+    "node_modules/stylelint-config-standard-scss": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-4.0.0.tgz",
+      "integrity": "sha512-xizu8PTEyB6zYXBiVg6VtvUYn9m57x+6ZtaOdaxsfpbe5eagLPGNlbYnKfm/CfN69ArUpnwR6LjgsTHzlGbtXQ==",
+      "dev": true,
+      "dependencies": {
+        "stylelint-config-recommended-scss": "^6.0.0",
+        "stylelint-config-standard": "^25.0.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.4.0"
+      }
+    },
+    "node_modules/stylelint-scss": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.2.0.tgz",
+      "integrity": "sha512-HHHMVKJJ5RM9pPIbgJ/XA67h9H0407G68Rm69H4fzFbFkyDMcTV1Byep3qdze5+fJ3c0U7mJrbj6S0Fg072uZA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.21",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.6",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "peerDependencies": {
+        "stylelint": "^14.5.1"
+      }
+    },
+    "node_modules/stylelint/node_modules/balanced-match": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+      "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+      "dev": true
+    },
+    "node_modules/stylelint/node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stylelint/node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/stylelint/node_modules/write-file-atomic": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+      "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+      "dev": true,
+      "dependencies": {
+        "imurmurhash": "^0.1.4",
+        "signal-exit": "^3.0.7"
+      },
+      "engines": {
+        "node": "^12.13.0 || ^14.15.0 || >=16"
       }
     },
     "node_modules/supports-color": {
@@ -7577,10 +8522,54 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
     "node_modules/symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "dev": true,
+      "dependencies": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/table/node_modules/ajv": {
+      "version": "8.11.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+      "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+      "dev": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.2.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/table/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
     },
     "node_modules/taffydb": {
@@ -7756,6 +8745,15 @@
       "dependencies": {
         "punycode": "^2.1.1"
       },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -7965,6 +8963,16 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "dependencies": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "node_modules/vary": {
@@ -8568,6 +9576,15 @@
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/yargs": {
       "version": "16.2.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
@@ -9030,6 +10047,13 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
+    "@csstools/selector-specificity": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-2.0.1.tgz",
+      "integrity": "sha512-aG20vknL4/YjQF9BSV7ts4EWm/yrjagAN7OWBNmlbEOUiu0llj4OGrFoOKK3g2vey4/p2omKCoHrWtPxSwV3HA==",
+      "dev": true,
+      "requires": {}
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -9373,6 +10397,32 @@
       "integrity": "sha512-Hcv+nVC0kZnQ3tD9GVu5xSMR4VVYOteQIr/hwFPVEvPdlXqgGEuRjiheChHgdM+JyqdgNcmzZOX/tnl0JOiI7A==",
       "dev": true
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      }
+    },
     "@sinonjs/commons": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.8.3.tgz",
@@ -9613,10 +10663,28 @@
       "integrity": "sha512-YATxVxgRqNH6nHEIsvg6k2Boc1JHI9ZbH5iWFFv/MTkchz3b1ieGDa5T0a9RznNdI0KhVbdbWSN+KWWrQZRxTw==",
       "dev": true
     },
+    "@types/minimist": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.2.tgz",
+      "integrity": "sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==",
+      "dev": true
+    },
     "@types/node": {
       "version": "17.0.21",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
       "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "dev": true
+    },
+    "@types/normalize-package-data": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
+      "integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==",
+      "dev": true
+    },
+    "@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
       "dev": true
     },
     "@types/prettier": {
@@ -10072,6 +11140,12 @@
         "is-string": "^1.0.7"
       }
     },
+    "array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "dev": true
+    },
     "array.prototype.flat": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.5.tgz",
@@ -10082,6 +11156,18 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.0"
       }
+    },
+    "arrify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+      "integrity": "sha512-3CYzex9M9FGQjCGMGyi6/31c8GJbgb0qGyrx5HWxPd0aCwh4cB2YjMb2Xf9UuoogrMrlO9cTqnB5rI5GHZTcUA==",
+      "dev": true
+    },
+    "astral-regex": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+      "integrity": "sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==",
+      "dev": true
     },
     "asynckit": {
       "version": "0.4.0",
@@ -10336,6 +11422,17 @@
       "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
       "dev": true
     },
+    "camelcase-keys": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-6.2.2.tgz",
+      "integrity": "sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==",
+      "dev": true,
+      "requires": {
+        "camelcase": "^5.3.1",
+        "map-obj": "^4.0.0",
+        "quick-lru": "^4.0.1"
+      }
+    },
     "caniuse-lite": {
       "version": "1.0.30001312",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz",
@@ -10443,6 +11540,15 @@
         "shallow-clone": "^3.0.0"
       }
     },
+    "clone-regexp": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/clone-regexp/-/clone-regexp-2.2.0.tgz",
+      "integrity": "sha512-beMpP7BOtTipFuW8hrJvREQ2DrRu3BE7by0ZpibtfBA+qfHYvMGTc2Yb1JMYPKg/JUw0CHYvpg796aNTSW9z7Q==",
+      "dev": true,
+      "requires": {
+        "is-regexp": "^2.0.0"
+      }
+    },
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
@@ -10468,6 +11574,12 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "colord": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.2.tgz",
+      "integrity": "sha512-Uqbg+J445nc1TKn4FoDPS6ZZqAvEDnwrH42yo8B40JSOgSLxMZ/gt3h4nmCtPLQeXhjJJkqBx7SCY35WnIixaQ==",
       "dev": true
     },
     "colorette": {
@@ -10606,6 +11718,19 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
+    "cosmiconfig": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.0.1.tgz",
+      "integrity": "sha512-a1YWNUV2HwGimB7dU2s1wUMurNKjpx60HxBB6xUM8Re+2s1g1IIfJvFR0/iCF+XHdE0GMTKTuLR32UQff4TEyQ==",
+      "dev": true,
+      "requires": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      }
+    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -10616,6 +11741,12 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "css-functions-list": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.1.0.tgz",
+      "integrity": "sha512-/9lCvYZaUbBGvYUgYGFJ4dcYiyqdhSjG7IPVluoV8A1ILjkF7ilmhp1OGUz8n+nmBcu0RNrQAzgD8B6FJbrt2w==",
+      "dev": true
     },
     "css-loader": {
       "version": "6.7.1",
@@ -10712,6 +11843,30 @@
         "ms": "2.1.2"
       }
     },
+    "decamelize": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==",
+      "dev": true
+    },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha512-ocLWuYzRPoS9bfiSdDd3cxvrzovVMZnRDVEzAs+hWIVXGDbHxWMECij2OBuyB/An0FFW/nLuq6Kv1i/YC5Qfzg==",
+      "dev": true,
+      "requires": {
+        "decamelize": "^1.1.0",
+        "map-obj": "^1.0.0"
+      },
+      "dependencies": {
+        "map-obj": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+          "integrity": "sha512-7N/q3lyZ+LVCp7PzuxrJr4KMbBE2hW7BT7YNia330OFxIf4d3r5zVpicP2650l7CPN6RM9zOJRl3NGpqSiw3Eg==",
+          "dev": true
+        }
+      }
+    },
     "decimal.js": {
       "version": "10.3.1",
       "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.3.1.tgz",
@@ -10795,6 +11950,15 @@
       "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
       "integrity": "sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==",
       "dev": true
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      }
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -11413,6 +12577,15 @@
         "strip-final-newline": "^2.0.0"
       }
     },
+    "execall": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/execall/-/execall-2.0.0.tgz",
+      "integrity": "sha512-0FU2hZ5Hh6iQnarpRtQurM/aAvp3RIbfvgLHrcqJYzhXyV2KFruhuChf9NC6waAhiUR7FFtlugkI4p7f2Fqlow==",
+      "dev": true,
+      "requires": {
+        "clone-regexp": "^2.1.0"
+      }
+    },
     "exit": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
@@ -11505,6 +12678,30 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.4"
+      },
+      "dependencies": {
+        "glob-parent": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+          "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+          "dev": true,
+          "requires": {
+            "is-glob": "^4.0.1"
+          }
+        }
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -11522,6 +12719,15 @@
       "resolved": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.12.tgz",
       "integrity": "sha512-On2N+BpYJ15xIC974QNVuYGMOlEVt4s0EOI3wwMqOmK1fdDY+FN/zltPV8vosq4ad4c/gJ1KHScUn/6AWIgiow==",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.13.0.tgz",
+      "integrity": "sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "faye-websocket": {
       "version": "0.11.4",
@@ -11706,6 +12912,12 @@
       "integrity": "sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==",
       "dev": true
     },
+    "get-stdin": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-8.0.0.tgz",
+      "integrity": "sha512-sY22aA6xchAzprjyqmSEQv4UbAAzRN0L2dQB0NlN5acTTK9Don6nhoc3eAbUnpZiCANAMfd/+40kVdKfFygohg==",
+      "dev": true
+    },
     "get-stream": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
@@ -11751,6 +12963,37 @@
       "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
       "dev": true
     },
+    "global-modules": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+      "integrity": "sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==",
+      "dev": true,
+      "requires": {
+        "global-prefix": "^3.0.0"
+      }
+    },
+    "global-prefix": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+      "integrity": "sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==",
+      "dev": true,
+      "requires": {
+        "ini": "^1.3.5",
+        "kind-of": "^6.0.2",
+        "which": "^1.3.1"
+      },
+      "dependencies": {
+        "which": {
+          "version": "1.3.1",
+          "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+          "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "globals": {
       "version": "13.13.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-13.13.0.tgz",
@@ -11759,6 +13002,26 @@
       "requires": {
         "type-fest": "^0.20.2"
       }
+    },
+    "globby": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
+      "dev": true,
+      "requires": {
+        "array-union": "^2.1.0",
+        "dir-glob": "^3.0.1",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
+        "slash": "^3.0.0"
+      }
+    },
+    "globjoin": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+      "integrity": "sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==",
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.2.9",
@@ -11770,6 +13033,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/handle-thing/-/handle-thing-2.0.1.tgz",
       "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
+      "dev": true
+    },
+    "hard-rejection": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
+      "integrity": "sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==",
       "dev": true
     },
     "has": {
@@ -11813,6 +13082,15 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "hosted-git-info": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
+      "dev": true,
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "hpack.js": {
       "version": "2.1.6",
@@ -11895,6 +13173,12 @@
           "dev": true
         }
       }
+    },
+    "html-tags": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+      "integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
+      "dev": true
     },
     "html-webpack-plugin": {
       "version": "5.5.0",
@@ -12041,6 +13325,12 @@
         "resolve-from": "^4.0.0"
       }
     },
+    "import-lazy": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/import-lazy/-/import-lazy-4.0.0.tgz",
+      "integrity": "sha512-rKtvo6a868b5Hu3heneU+L4yEQ4jYKLtjpnPeUdK7h0yzXGmyBTypknlkCvHFBqfX9YlorEiMM6Dnq/5atfHkw==",
+      "dev": true
+    },
     "import-local": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/import-local/-/import-local-3.1.0.tgz",
@@ -12057,6 +13347,12 @@
       "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
       "dev": true
     },
+    "indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true
+    },
     "inflight": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
@@ -12071,6 +13367,12 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "dev": true
     },
     "internal-slot": {
@@ -12238,6 +13540,12 @@
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
       }
+    },
+    "is-regexp": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-2.1.0.tgz",
+      "integrity": "sha512-OZ4IlER3zmRIoB9AqNhEggVxqIH4ofDns5nRrPS6yQxXE1TPCUpFznBfRQmQa8uC+pXqjMnukiJBxCisIxiLGA==",
+      "dev": true
     },
     "is-shared-array-buffer": {
       "version": "1.0.1",
@@ -13003,6 +14311,12 @@
       "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
       "dev": true
     },
+    "known-css-properties": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.25.0.tgz",
+      "integrity": "sha512-b0/9J1O9Jcyik1GC6KC42hJ41jKwdO/Mq8Mdo5sYN+IuRTXs2YFHZC3kZSx6ueusqa95x3wLYe/ytKjbAfGixA==",
+      "dev": true
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -13061,6 +14375,12 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
     },
+    "lodash.truncate": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+      "integrity": "sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==",
+      "dev": true
+    },
     "lower-case": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lower-case/-/lower-case-2.0.2.tgz",
@@ -13097,6 +14417,12 @@
         "tmpl": "1.0.5"
       }
     },
+    "map-obj": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-4.3.0.tgz",
+      "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
+      "dev": true
+    },
     "markdown-it": {
       "version": "12.3.2",
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-12.3.2.tgz",
@@ -13123,6 +14449,12 @@
       "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "dev": true
     },
+    "mathml-tag-names": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+      "integrity": "sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==",
+      "dev": true
+    },
     "mdurl": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -13144,6 +14476,34 @@
         "fs-monkey": "1.0.3"
       }
     },
+    "meow": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/meow/-/meow-9.0.0.tgz",
+      "integrity": "sha512-+obSblOQmRhcyBt62furQqRAQpNyWXo8BuQ5bN7dG8wmwQ+vwHKp/rCFD4CrTP8CsDQD1sjoZ94K417XEUk8IQ==",
+      "dev": true,
+      "requires": {
+        "@types/minimist": "^1.2.0",
+        "camelcase-keys": "^6.2.2",
+        "decamelize": "^1.2.0",
+        "decamelize-keys": "^1.1.0",
+        "hard-rejection": "^2.1.0",
+        "minimist-options": "4.1.0",
+        "normalize-package-data": "^3.0.0",
+        "read-pkg-up": "^7.0.1",
+        "redent": "^3.0.0",
+        "trim-newlines": "^3.0.0",
+        "type-fest": "^0.18.0",
+        "yargs-parser": "^20.2.3"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.18.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.18.1.tgz",
+          "integrity": "sha512-OIAYXk8+ISY+qTOwkHtKqzAuxchoMiD9Udx+FSGQDuiRR+PJKJHc2NJAXlbhkGwTt/4/nKZxELY1w3ReWOL8mw==",
+          "dev": true
+        }
+      }
+    },
     "merge-descriptors": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
@@ -13156,6 +14516,12 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
     },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "dev": true
+    },
     "methods": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
@@ -13163,13 +14529,13 @@
       "dev": true
     },
     "micromatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+      "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "requires": {
-        "braces": "^3.0.1",
-        "picomatch": "^2.2.3"
+        "braces": "^3.0.2",
+        "picomatch": "^2.3.1"
       }
     },
     "mime": {
@@ -13199,6 +14565,12 @@
       "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
       "dev": true
     },
+    "min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true
+    },
     "minimalistic-assert": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
@@ -13219,6 +14591,25 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "minimist-options": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-4.1.0.tgz",
+      "integrity": "sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.1",
+        "is-plain-obj": "^1.1.0",
+        "kind-of": "^6.0.3"
+      },
+      "dependencies": {
+        "is-plain-obj": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+          "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
+          "dev": true
+        }
+      }
     },
     "mkdirp": {
       "version": "1.0.4",
@@ -13293,6 +14684,29 @@
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.2.tgz",
       "integrity": "sha512-XxYDdcQ6eKqp/YjI+tb2C5WM2LgjnZrfYg4vgQt49EK268b6gYCHsBLrK2qvJo4FmCtqmKezb0WZFK4fkrZNsg==",
       "dev": true
+    },
+    "normalize-package-data": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-3.0.3.tgz",
+      "integrity": "sha512-p2W1sgqij3zMMyRC067Dg16bfzVH+w7hyegmpIvZ4JNjqtGOVAIvLmjBx3yP7YTe9vKJgkoNOPjwQGogDoMXFA==",
+      "dev": true,
+      "requires": {
+        "hosted-git-info": "^4.0.1",
+        "is-core-module": "^2.5.0",
+        "semver": "^7.3.4",
+        "validate-npm-package-license": "^3.0.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -13551,6 +14965,12 @@
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ==",
       "dev": true
     },
+    "path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "dev": true
+    },
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
@@ -13589,6 +15009,12 @@
         "source-map-js": "^1.0.2"
       }
     },
+    "postcss-media-query-parser": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/postcss-media-query-parser/-/postcss-media-query-parser-0.2.3.tgz",
+      "integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
+      "dev": true
+    },
     "postcss-modules-extract-imports": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
@@ -13624,6 +15050,26 @@
       "requires": {
         "icss-utils": "^5.0.0"
       }
+    },
+    "postcss-resolve-nested-selector": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.1.tgz",
+      "integrity": "sha512-HvExULSwLqHLgUy1rl3ANIqCsvMS0WHss2UOsXhXnQaZ9VCc2oBvIpXrl00IUFT5ZDITME0o6oiXeiHr2SAIfw==",
+      "dev": true
+    },
+    "postcss-safe-parser": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-6.0.0.tgz",
+      "integrity": "sha512-FARHN8pwH+WiS2OPCxJI8FuRJpTVnn6ZNFiqAM2aeW2LwTHWWmWgIyKC6cUo0L8aeKiF/14MNvnpls6R2PBeMQ==",
+      "dev": true,
+      "requires": {}
+    },
+    "postcss-scss": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-4.0.4.tgz",
+      "integrity": "sha512-aBBbVyzA8b3hUL0MGrpydxxXKXFZc5Eqva0Q3V9qsBOLEMsjb6w49WfpsoWzpEgcqJGW4t7Rio8WXVU9Gd8vWg==",
+      "dev": true,
+      "requires": {}
     },
     "postcss-selector-parser": {
       "version": "6.0.10",
@@ -13736,6 +15182,18 @@
         "side-channel": "^1.0.4"
       }
     },
+    "queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-4.0.1.tgz",
+      "integrity": "sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==",
+      "dev": true
+    },
     "randombytes": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
@@ -13777,6 +15235,69 @@
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true
     },
+    "read-pkg": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+      "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
+      "dev": true,
+      "requires": {
+        "@types/normalize-package-data": "^2.4.0",
+        "normalize-package-data": "^2.5.0",
+        "parse-json": "^5.0.0",
+        "type-fest": "^0.6.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "2.8.9",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.8.9.tgz",
+          "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
+          "dev": true
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "type-fest": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+          "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
+          "dev": true
+        }
+      }
+    },
+    "read-pkg-up": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-7.0.1.tgz",
+      "integrity": "sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==",
+      "dev": true,
+      "requires": {
+        "find-up": "^4.1.0",
+        "read-pkg": "^5.2.0",
+        "type-fest": "^0.8.1"
+      },
+      "dependencies": {
+        "type-fest": {
+          "version": "0.8.1",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
+          "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
+          "dev": true
+        }
+      }
+    },
     "readable-stream": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
@@ -13804,6 +15325,16 @@
       "dev": true,
       "requires": {
         "resolve": "^1.9.0"
+      }
+    },
+    "redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "requires": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
       }
     },
     "regexpp": {
@@ -13924,6 +15455,12 @@
       "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -13931,6 +15468,15 @@
       "dev": true,
       "requires": {
         "glob": "^7.1.3"
+      }
+    },
+    "run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "dev": true,
+      "requires": {
+        "queue-microtask": "^1.2.2"
       }
     },
     "safe-buffer": {
@@ -14201,6 +15747,17 @@
       "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
       "dev": true
     },
+    "slice-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+      "integrity": "sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^4.0.0",
+        "astral-regex": "^2.0.0",
+        "is-fullwidth-code-point": "^3.0.0"
+      }
+    },
     "slimdom": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/slimdom/-/slimdom-3.1.0.tgz",
@@ -14237,6 +15794,16 @@
       "requires": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
+      }
+    },
+    "spdx-correct": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
+      "dev": true,
+      "requires": {
+        "spdx-expression-parse": "^3.0.0",
+        "spdx-license-ids": "^3.0.0"
       }
     },
     "spdx-exceptions": {
@@ -14388,6 +15955,15 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "dev": true
     },
+    "strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "requires": {
+        "min-indent": "^1.0.0"
+      }
+    },
     "strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -14400,6 +15976,140 @@
       "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
       "dev": true,
       "requires": {}
+    },
+    "style-search": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
+      "integrity": "sha512-Dj1Okke1C3uKKwQcetra4jSuk0DqbzbYtXipzFlFMZtowbF1x7BKJwB9AayVMyFARvU8EDrZdcax4At/452cAg==",
+      "dev": true
+    },
+    "stylelint": {
+      "version": "14.9.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.9.1.tgz",
+      "integrity": "sha512-RdAkJdPiLqHawCSnu21nE27MjNXaVd4WcOHA4vK5GtIGjScfhNnaOuWR2wWdfKFAvcWQPOYe311iveiVKSmwsA==",
+      "dev": true,
+      "requires": {
+        "@csstools/selector-specificity": "^2.0.1",
+        "balanced-match": "^2.0.0",
+        "colord": "^2.9.2",
+        "cosmiconfig": "^7.0.1",
+        "css-functions-list": "^3.1.0",
+        "debug": "^4.3.4",
+        "execall": "^2.0.0",
+        "fast-glob": "^3.2.11",
+        "fastest-levenshtein": "^1.0.12",
+        "file-entry-cache": "^6.0.1",
+        "get-stdin": "^8.0.0",
+        "global-modules": "^2.0.0",
+        "globby": "^11.1.0",
+        "globjoin": "^0.1.4",
+        "html-tags": "^3.2.0",
+        "ignore": "^5.2.0",
+        "import-lazy": "^4.0.0",
+        "imurmurhash": "^0.1.4",
+        "is-plain-object": "^5.0.0",
+        "known-css-properties": "^0.25.0",
+        "mathml-tag-names": "^2.1.3",
+        "meow": "^9.0.0",
+        "micromatch": "^4.0.5",
+        "normalize-path": "^3.0.0",
+        "picocolors": "^1.0.0",
+        "postcss": "^8.4.14",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-safe-parser": "^6.0.0",
+        "postcss-selector-parser": "^6.0.10",
+        "postcss-value-parser": "^4.2.0",
+        "resolve-from": "^5.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "style-search": "^0.1.0",
+        "supports-hyperlinks": "^2.2.0",
+        "svg-tags": "^1.0.0",
+        "table": "^6.8.0",
+        "v8-compile-cache": "^2.3.0",
+        "write-file-atomic": "^4.0.1"
+      },
+      "dependencies": {
+        "balanced-match": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+          "integrity": "sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==",
+          "dev": true
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+          "dev": true
+        },
+        "resolve-from": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+          "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+          "dev": true
+        },
+        "write-file-atomic": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-4.0.1.tgz",
+          "integrity": "sha512-nSKUxgAbyioruk6hU87QzVbY279oYT6uiwgDoujth2ju4mJ+TZau7SQBhtbTmUyuNYTuXnSyRn66FV0+eCgcrQ==",
+          "dev": true,
+          "requires": {
+            "imurmurhash": "^0.1.4",
+            "signal-exit": "^3.0.7"
+          }
+        }
+      }
+    },
+    "stylelint-config-recommended": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-7.0.0.tgz",
+      "integrity": "sha512-yGn84Bf/q41J4luis1AZ95gj0EQwRX8lWmGmBwkwBNSkpGSpl66XcPTulxGa/Z91aPoNGuIGBmFkcM1MejMo9Q==",
+      "dev": true,
+      "requires": {}
+    },
+    "stylelint-config-recommended-scss": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-recommended-scss/-/stylelint-config-recommended-scss-6.0.0.tgz",
+      "integrity": "sha512-6QOe2/OzXV2AP5FE12A7+qtKdZik7Saf42SMMl84ksVBBPpTdrV+9HaCbPYiRMiwELY9hXCVdH4wlJ+YJb5eig==",
+      "dev": true,
+      "requires": {
+        "postcss-scss": "^4.0.2",
+        "stylelint-config-recommended": "^7.0.0",
+        "stylelint-scss": "^4.0.0"
+      }
+    },
+    "stylelint-config-standard": {
+      "version": "25.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-25.0.0.tgz",
+      "integrity": "sha512-21HnP3VSpaT1wFjFvv9VjvOGDtAviv47uTp3uFmzcN+3Lt+RYRv6oAplLaV51Kf792JSxJ6svCJh/G18E9VnCA==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended": "^7.0.0"
+      }
+    },
+    "stylelint-config-standard-scss": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/stylelint-config-standard-scss/-/stylelint-config-standard-scss-4.0.0.tgz",
+      "integrity": "sha512-xizu8PTEyB6zYXBiVg6VtvUYn9m57x+6ZtaOdaxsfpbe5eagLPGNlbYnKfm/CfN69ArUpnwR6LjgsTHzlGbtXQ==",
+      "dev": true,
+      "requires": {
+        "stylelint-config-recommended-scss": "^6.0.0",
+        "stylelint-config-standard": "^25.0.0"
+      }
+    },
+    "stylelint-scss": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-4.2.0.tgz",
+      "integrity": "sha512-HHHMVKJJ5RM9pPIbgJ/XA67h9H0407G68Rm69H4fzFbFkyDMcTV1Byep3qdze5+fJ3c0U7mJrbj6S0Fg072uZA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.21",
+        "postcss-media-query-parser": "^0.2.3",
+        "postcss-resolve-nested-selector": "^0.1.1",
+        "postcss-selector-parser": "^6.0.6",
+        "postcss-value-parser": "^4.1.0"
+      }
     },
     "supports-color": {
       "version": "7.2.0",
@@ -14426,11 +16136,50 @@
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
     },
+    "svg-tags": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+      "integrity": "sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==",
+      "dev": true
+    },
     "symbol-tree": {
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
+    },
+    "table": {
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/table/-/table-6.8.0.tgz",
+      "integrity": "sha512-s/fitrbVeEyHKFa7mFdkuQMWlH1Wgw/yEXMt5xACT4ZpzWFluehAxRtUUQKPuWhaLAWhFcVx6w3oC8VKaUfPGA==",
+      "dev": true,
+      "requires": {
+        "ajv": "^8.0.1",
+        "lodash.truncate": "^4.4.2",
+        "slice-ansi": "^4.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.11.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+          "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
+          "dev": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.1",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.2.2"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "dev": true
+        }
+      }
     },
     "taffydb": {
       "version": "2.6.2",
@@ -14554,6 +16303,12 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "trim-newlines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-3.0.1.tgz",
+      "integrity": "sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==",
+      "dev": true
     },
     "tsconfig-paths": {
       "version": "3.12.0",
@@ -14722,6 +16477,16 @@
           "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
           "dev": true
         }
+      }
+    },
+    "validate-npm-package-license": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
+      "integrity": "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==",
+      "dev": true,
+      "requires": {
+        "spdx-correct": "^3.0.0",
+        "spdx-expression-parse": "^3.0.0"
       }
     },
     "vary": {
@@ -15156,6 +16921,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
+    },
+    "yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
       "dev": true
     },
     "yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@types/markdown-it": "^12.2.3",
+        "css-loader": "^6.7.1",
         "eslint": "^8.11.0",
         "eslint-config-airbnb-base": "^15.0.0",
         "eslint-plugin-import": "^2.25.4",
@@ -25,6 +26,9 @@
         "jsdoc": "^3.6.10",
         "jsdoc-tsimport-plugin": "^1.0.5",
         "markdown-it": "^12.3.2",
+        "sass": "^1.52.3",
+        "sass-loader": "^13.0.0",
+        "style-loader": "^3.3.1",
         "webpack": "^5.73.0",
         "webpack-cli": "^4.9.2",
         "webpack-dev-server": "^4.9.2"
@@ -2499,6 +2503,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-loader": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+      "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.7",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/css-loader/node_modules/semver": {
+      "version": "7.3.7",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+      "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -2525,6 +2570,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "dev": true,
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/cssom": {
@@ -4296,6 +4353,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
@@ -4304,6 +4373,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
+      "dev": true
     },
     "node_modules/import-fresh": {
       "version": "3.3.0",
@@ -5603,6 +5678,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/klona": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -5912,6 +5996,18 @@
       },
       "bin": {
         "multicast-dns": "cli.js"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/natural-compare": {
@@ -6349,6 +6445,108 @@
         "node": ">=8"
       }
     },
+    "node_modules/postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "dependencies": {
+        "postcss-selector-parser": "^6.0.4"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "dependencies": {
+        "icss-utils": "^5.0.0"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >= 14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
     "node_modules/prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -6746,6 +6944,61 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sass": {
+      "version": "1.52.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.3.tgz",
+      "integrity": "sha512-LNNPJ9lafx+j1ArtA7GyEJm9eawXN8KlA1+5dF6IZyoONg1Tyo/g+muOsENWJH/2Q1FHbbV4UwliU0cXMa/VIA==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      },
+      "bin": {
+        "sass": "sass.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/sass-loader": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.0.tgz",
+      "integrity": "sha512-IHCFecI+rbPvXE2zO/mqdVFe8MU7ElGrwga9hh2H65Ru4iaBJAMRteum1c4Gsxi9Cq1FOtTEDd6+/AEYuQDM4Q==",
+      "dev": true,
+      "dependencies": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
+      },
+      "engines": {
+        "node": ">= 14.15.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "fibers": ">= 3.1.0",
+        "node-sass": "^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0",
+        "sass": "^1.3.0",
+        "sass-embedded": "*",
+        "webpack": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "fibers": {
+          "optional": true
+        },
+        "node-sass": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -7049,6 +7302,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -7260,6 +7522,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-loader": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 12.13.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.0.0"
       }
     },
     "node_modules/supports-color": {
@@ -10339,6 +10617,33 @@
         "which": "^2.0.1"
       }
     },
+    "css-loader": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/css-loader/-/css-loader-6.7.1.tgz",
+      "integrity": "sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.1.0",
+        "postcss": "^8.4.7",
+        "postcss-modules-extract-imports": "^3.0.0",
+        "postcss-modules-local-by-default": "^4.0.0",
+        "postcss-modules-scope": "^3.0.0",
+        "postcss-modules-values": "^4.0.0",
+        "postcss-value-parser": "^4.2.0",
+        "semver": "^7.3.5"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.3.7",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
+          "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "css-select": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/css-select/-/css-select-4.3.0.tgz",
@@ -10356,6 +10661,12 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
       "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "dev": true
+    },
+    "cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
       "dev": true
     },
     "cssom": {
@@ -11701,10 +12012,23 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "icss-utils": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
+      "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
+      "dev": true,
+      "requires": {}
+    },
     "ignore": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
       "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
+      "dev": true
+    },
+    "immutable": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.1.0.tgz",
+      "integrity": "sha512-oNkuqVTA8jqG1Q6c+UglTOD1xhC1BtjKI7XkCXRkZHrN5m18/XsnUp8Q89GkQO/z+0WjonSvl0FLhDYftp46nQ==",
       "dev": true
     },
     "import-fresh": {
@@ -12673,6 +12997,12 @@
       "integrity": "sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==",
       "dev": true
     },
+    "klona": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/klona/-/klona-2.0.5.tgz",
+      "integrity": "sha512-pJiBpiXMbt7dkzXe8Ghj/u4FfXOOa98fPW+bihOJ4SjnoijweJrNThJfd3ifXpXhREjpoF2mZVH1GfS9LV3kHQ==",
+      "dev": true
+    },
     "leven": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/leven/-/leven-3.1.0.tgz",
@@ -12911,6 +13241,12 @@
         "dns-packet": "^5.2.2",
         "thunky": "^1.0.2"
       }
+    },
+    "nanoid": {
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.4.tgz",
+      "integrity": "sha512-MqBkQh/OHTS2egovRtLk45wEyNXwF+cokD+1YPf9u5VfJiRdAiRwB2froX5Co9Rh20xs4siNPm8naNotSD6RBw==",
+      "dev": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -13242,6 +13578,69 @@
         "find-up": "^4.0.0"
       }
     },
+    "postcss": {
+      "version": "8.4.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.14.tgz",
+      "integrity": "sha512-E398TUmfAYFPBSdzgeieK2Y1+1cpdxJx8yXbK/m57nRhKSmk1GB2tO4lbLBtlkfPQTDKfe4Xqv1ASWPpayPEig==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.3.4",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      }
+    },
+    "postcss-modules-extract-imports": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
+      "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
+      "dev": true,
+      "requires": {}
+    },
+    "postcss-modules-local-by-default": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-4.0.0.tgz",
+      "integrity": "sha512-sT7ihtmGSF9yhm6ggikHdV0hlziDTX7oFoXtuVWeDd3hHObNkcHRo9V3yg7vCAY7cONyxJC/XXCmmiHHcvX7bQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0",
+        "postcss-selector-parser": "^6.0.2",
+        "postcss-value-parser": "^4.1.0"
+      }
+    },
+    "postcss-modules-scope": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-3.0.0.tgz",
+      "integrity": "sha512-hncihwFA2yPath8oZ15PZqvWGkWf+XUfQgUGamS4LqoP1anQLOsOJw0vr7J7IwLpoY9fatA2qiGUGmuZL0Iqlg==",
+      "dev": true,
+      "requires": {
+        "postcss-selector-parser": "^6.0.4"
+      }
+    },
+    "postcss-modules-values": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-values/-/postcss-modules-values-4.0.0.tgz",
+      "integrity": "sha512-RDxHkAiEGI78gS2ofyvCsu7iycRv7oqw5xMWn9iMoR0N/7mf9D50ecQqUo5BZ9Zh2vH4bCUR/ktCqbB9m8vJjQ==",
+      "dev": true,
+      "requires": {
+        "icss-utils": "^5.0.0"
+      }
+    },
+    "postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "requires": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      }
+    },
+    "postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true
+    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -13546,6 +13945,27 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sass": {
+      "version": "1.52.3",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.52.3.tgz",
+      "integrity": "sha512-LNNPJ9lafx+j1ArtA7GyEJm9eawXN8KlA1+5dF6IZyoONg1Tyo/g+muOsENWJH/2Q1FHbbV4UwliU0cXMa/VIA==",
+      "dev": true,
+      "requires": {
+        "chokidar": ">=3.0.0 <4.0.0",
+        "immutable": "^4.0.0",
+        "source-map-js": ">=0.6.2 <2.0.0"
+      }
+    },
+    "sass-loader": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/sass-loader/-/sass-loader-13.0.0.tgz",
+      "integrity": "sha512-IHCFecI+rbPvXE2zO/mqdVFe8MU7ElGrwga9hh2H65Ru4iaBJAMRteum1c4Gsxi9Cq1FOtTEDd6+/AEYuQDM4Q==",
+      "dev": true,
+      "requires": {
+        "klona": "^2.0.4",
+        "neo-async": "^2.6.2"
+      }
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -13803,6 +14223,12 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+      "dev": true
+    },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -13967,6 +14393,13 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "dev": true
+    },
+    "style-loader": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/style-loader/-/style-loader-3.3.1.tgz",
+      "integrity": "sha512-GPcQ+LDJbrcxHORTRes6Jy2sfvK2kS6hpSfI/fXhPt+spVzxF6LJ1dHLN9zIGmVaaP044YKaIatFaufENRiDoQ==",
+      "dev": true,
+      "requires": {}
     },
     "supports-color": {
       "version": "7.2.0",

--- a/package.json
+++ b/package.json
@@ -10,8 +10,12 @@
   "homepage": "https://github.com/digitalocean/do-markdownit#readme",
   "bugs": "https://github.com/digitalocean/do-markdownit/issues",
   "scripts": {
-    "lint": "eslint \"{*,@(modifiers|rules|script|util|dev)/**/*}.js\" --ignore-pattern \"dev/dist/**/*\"",
-    "lint:fix": "npm run lint -- --fix",
+    "lint": "npm run lint:js && npm run lint:scss",
+    "lint:fix": "npm run lint:js:fix && npm run lint:scss:fix",
+    "lint:js": "eslint \"{*,@(modifiers|rules|script|util|dev)/**/*}.js\" --ignore-pattern \"dev/dist/**/*\"",
+    "lint:js:fix": "npm run lint:js -- --fix",
+    "lint:scss": "stylelint \"@(styles|dev)/**/*.scss\"",
+    "lint:scss:fix": "npm run lint:scss -- --fix",
     "jsdoc": "jsdoc -c .jsdoc.json",
     "test": "jest",
     "postinstall": "node script/prism.js",
@@ -37,6 +41,8 @@
     "sass": "^1.52.3",
     "sass-loader": "^13.0.0",
     "style-loader": "^3.3.1",
+    "stylelint": "^14.9.1",
+    "stylelint-config-standard-scss": "^4.0.0",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.9.2"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   },
   "devDependencies": {
     "@types/markdown-it": "^12.2.3",
+    "css-loader": "^6.7.1",
     "eslint": "^8.11.0",
     "eslint-config-airbnb-base": "^15.0.0",
     "eslint-plugin-import": "^2.25.4",
@@ -33,6 +34,9 @@
     "jsdoc": "^3.6.10",
     "jsdoc-tsimport-plugin": "^1.0.5",
     "markdown-it": "^12.3.2",
+    "sass": "^1.52.3",
+    "sass-loader": "^13.0.0",
+    "style-loader": "^3.3.1",
     "webpack": "^5.73.0",
     "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.9.2"

--- a/rules/embeds/callout.js
+++ b/rules/embeds/callout.js
@@ -169,7 +169,7 @@ module.exports = (md, options) => {
      */
     md.renderer.rules.callout_open = (tokens, index) => {
         const token = tokens[index];
-        const classes = [ ...(optsObj.extraClasses || ['callout']), token.callout.className ].join(' ');
+        const classes = [ ...(optsObj.extraClasses || [ 'callout' ]), token.callout.className ].join(' ');
         return `<div class="${md.utils.escapeHtml(classes)}">\n`;
     };
 

--- a/rules/embeds/callout.js
+++ b/rules/embeds/callout.js
@@ -25,7 +25,7 @@ const safeObject = require('../../util/safe_object');
 /**
  * @typedef {Object} CalloutOptions
  * @property {string[]} [allowedClasses] List of case-sensitive classes that are allowed. If not an array, all classes are allowed.
- * @property {string[]} [extraClasses=[]] List of extra classes to apply to a callout div, alongside the given class.
+ * @property {string[]} [extraClasses=['callout']] List of extra classes to apply to a callout div, alongside the given class.
  * @property {string} [labelClass='callout-label'] Class to use for the label.
  */
 
@@ -50,11 +50,11 @@ const safeObject = require('../../util/safe_object');
  * world
  * <$>
  *
- * <div class="info">
+ * <div class="callout info">
  * <p>test</p>
  * </div>
  *
- * <div class="info">
+ * <div class="callout info">
  * <p class="callout-label">hello</p>
  * <p>world</p>
  * </div>
@@ -169,9 +169,7 @@ module.exports = (md, options) => {
      */
     md.renderer.rules.callout_open = (tokens, index) => {
         const token = tokens[index];
-        const classes = optsObj.extraClasses
-            ? `${optsObj.extraClasses} ${token.callout.className}`
-            : `${token.callout.className}`;
+        const classes = [ ...(optsObj.extraClasses || ['callout']), token.callout.className ].join(' ');
         return `<div class="${md.utils.escapeHtml(classes)}">\n`;
     };
 

--- a/rules/embeds/callout.test.js
+++ b/rules/embeds/callout.test.js
@@ -19,21 +19,21 @@ limitations under the License.
 const md = require('markdown-it')().use(require('./callout'));
 
 it('handles callout embeds (not inline)', () => {
-    expect(md.render('<$>[info]\ntest\n<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]\ntest\n<$>')).toBe(`<div class="callout info">
 <p>test</p>
 </div>
 `);
 });
 
 it('handles callout embeds with no linebreaks', () => {
-    expect(md.render('<$>[info]test<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]test<$>')).toBe(`<div class="callout info">
 <p>test</p>
 </div>
 `);
 });
 
 it('handles callout embeds with multiple linebreaks', () => {
-    expect(md.render('<$>[info]\ntest\n\nhello\n\nworld\n<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]\ntest\n\nhello\n\nworld\n<$>')).toBe(`<div class="callout info">
 <p>test</p>
 <p>hello</p>
 <p>world</p>
@@ -42,21 +42,21 @@ it('handles callout embeds with multiple linebreaks', () => {
 });
 
 it('handles callout embeds with markdown', () => {
-    expect(md.render('<$>[info]\ntest **hello** world\n<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]\ntest **hello** world\n<$>')).toBe(`<div class="callout info">
 <p>test <strong>hello</strong> world</p>
 </div>
 `);
 });
 
 it('handles callout embeds with no linebreaks and markdown', () => {
-    expect(md.render('<$>[info]test **hello** world<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]test **hello** world<$>')).toBe(`<div class="callout info">
 <p>test <strong>hello</strong> world</p>
 </div>
 `);
 });
 
 it('handles callout embeds with mixed linebreaks and markdown', () => {
-    expect(md.render('<$>[info]test **hello** world\n\nmore *content* tests\n<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]test **hello** world\n\nmore *content* tests\n<$>')).toBe(`<div class="callout info">
 <p>test <strong>hello</strong> world</p>
 <p>more <em>content</em> tests</p>
 </div>
@@ -64,14 +64,14 @@ it('handles callout embeds with mixed linebreaks and markdown', () => {
 });
 
 it('handles callout embeds with a label', () => {
-    expect(md.render('<$>[info]\n[label hello]\n<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]\n[label hello]\n<$>')).toBe(`<div class="callout info">
 <p class="callout-label">hello</p>
 </div>
 `);
 });
 
 it('handles callout embeds with a label and content', () => {
-    expect(md.render('<$>[info]\n[label hello]\nworld\n<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]\n[label hello]\nworld\n<$>')).toBe(`<div class="callout info">
 <p class="callout-label">hello</p>
 <p>world</p>
 </div>
@@ -79,7 +79,7 @@ it('handles callout embeds with a label and content', () => {
 });
 
 it('handles callout embeds with a label using markdown', () => {
-    expect(md.render('<$>[info]\n[label **hello**]\nworld\n<$>')).toBe(`<div class="info">
+    expect(md.render('<$>[info]\n[label **hello**]\nworld\n<$>')).toBe(`<div class="callout info">
 <p class="callout-label"><strong>hello</strong></p>
 <p>world</p>
 </div>
@@ -89,7 +89,7 @@ it('handles callout embeds with a label using markdown', () => {
 const mdAllowed = require('markdown-it')().use(require('./callout'), { allowedClasses: [ 'test' ] });
 
 it('handles callout embeds with an allowed class name', () => {
-    expect(mdAllowed.render('<$>[test]\nhello\n<$>')).toBe(`<div class="test">
+    expect(mdAllowed.render('<$>[test]\nhello\n<$>')).toBe(`<div class="callout test">
 <p>hello</p>
 </div>
 `);

--- a/rules/embeds/caniuse.js
+++ b/rules/embeds/caniuse.js
@@ -23,6 +23,7 @@ limitations under the License.
 const safeObject = require('../../util/safe_object');
 /**
  * Add support for [CanIUse](https://caniuse.com/) embeds in Markdown, as block syntax.
+ *
  * Uses https://caniuse.bitsofco.de/ to provide interactive embeds from CanIUse data.
  *
  * The basic syntax is `[caniuse <feature>]`. E.g. `[caniuse css-grid]`.

--- a/styles/_breakpoints.scss
+++ b/styles/_breakpoints.scss
@@ -1,0 +1,30 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+
+$smallPhone: 320 !default;
+$phone: 375 !default;
+$largePhone: 425 !default;
+$tablet: 768 !default;
+$desktop: 1024 !default;
+$mediumDesktop: 1220 !default;
+$largeDesktop: 1440 !default;
+
+@mixin mQ($size, $limit: 'max', $unit: 'px') {
+    @media only screen and (#{$limit}-width: #{$size}#{$unit}) {
+        @content;
+    }
+}

--- a/styles/_callouts.scss
+++ b/styles/_callouts.scss
@@ -14,10 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
+@import "theme";
 
-$calloutsClass: 'callout' !default;
-$calloutsLabelClass: 'callout-label' !default;
+$calloutsClass: "callout" !default;
+$calloutsLabelClass: "callout-label" !default;
 
 // Callouts
 .#{$calloutsClass} {

--- a/styles/_callouts.scss
+++ b/styles/_callouts.scss
@@ -1,0 +1,51 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'theme';
+
+$calloutsClass: 'callout' !default;
+$calloutsLabelClass: 'callout-label' !default;
+
+// Callouts
+.#{$calloutsClass} {
+    background-color: $blue5;
+    border-radius: 16px;
+    color: $blue1;
+    display: block;
+    font-size: 15px;
+    line-height: 1.5em;
+    margin: 0 0 1.5em;
+    padding: 1em 1.25em;
+    position: relative;
+    z-index: 0;
+
+    > :first-child {
+        margin-top: 0;
+    }
+
+    > :last-child {
+        margin-bottom: 0;
+    }
+
+    .#{$calloutsLabelClass} {
+        background: rgba($black, 0.1);
+        border-radius: 16px 16px 0 0;
+        font-size: 15px;
+        margin: -1em -1.25em 0;
+        padding: 0.75em 1.25em;
+        text-align: center;
+    }
+}

--- a/styles/_callouts.scss
+++ b/styles/_callouts.scss
@@ -16,11 +16,11 @@ limitations under the License.
 
 @import "theme";
 
-$calloutsClass: "callout" !default;
-$calloutsLabelClass: "callout-label" !default;
+$callouts-class: "callout" !default;
+$callouts-label-class: "callout-label" !default;
 
 // Callouts
-.#{$calloutsClass} {
+.#{$callouts-class} {
     background-color: $blue5;
     border-radius: 16px;
     color: $blue1;
@@ -40,7 +40,7 @@ $calloutsLabelClass: "callout-label" !default;
         margin-bottom: 0;
     }
 
-    .#{$calloutsLabelClass} {
+    .#{$callouts-label-class} {
         background: rgba($black, 0.1);
         border-radius: 16px 16px 0 0;
         font-size: 15px;

--- a/styles/_code.scss
+++ b/styles/_code.scss
@@ -30,7 +30,7 @@ code {
 
 // Code blocks
 pre {
-    @include codeBlockTheme($gray2, $white);
+    @include code-block-theme($gray2, $white);
 
     border-radius: 16px;
     display: block;

--- a/styles/_code.scss
+++ b/styles/_code.scss
@@ -23,7 +23,6 @@ code {
     background-color: $gray8;
     border-radius: 8px;
     color: $gray3;
-    //font-family: ${fontFamilyHelper('code')};
     font-size: 14px;
     line-height: 1.4em;
     padding: 3px;

--- a/styles/_code.scss
+++ b/styles/_code.scss
@@ -16,33 +16,36 @@ limitations under the License.
 
 @import 'theme';
 
-// Highlight
-mark {
-    background: rgba($highlight, 0.35);
+// Inline code
+pre,
+code {
+    background-color: $gray8;
     border-radius: 8px;
-    color: inherit;
-    display: inline;
-    line-height: calc(1.4em + 1px);
-    padding: 0 2px;
-
-    // Ignore any nested highlighting
-    mark {
-        background: none;
-        border-radius: initial;
-        line-height: 1.4em;
-        padding: initial;
-    }
+    color: $gray3;
+    //font-family: ${fontFamilyHelper('code')};
+    font-size: 14px;
+    line-height: 1.4em;
+    padding: 3px;
 }
 
-// Highlights in code
+// Code blocks
 pre {
-    code {
-        mark {
-            background: rgba($highlightDark, 0.35);
+    background-color: $codeBlockBackground;
+    border-radius: 16px;
+    color: $codeBlockText;
+    display: block;
+    margin: 1em 0;
+    overflow: auto;
+    overflow-wrap: normal;
+    padding: 1em;
+    white-space: normal;
+    word-wrap: normal;
 
-            mark {
-                background: none;
-            }
-        }
+    code {
+        background: 0;
+        border-radius: 0;
+        color: inherit;
+        padding: 0;
+        white-space: pre;
     }
 }

--- a/styles/_code.scss
+++ b/styles/_code.scss
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
-@import 'mixins';
+@import "theme";
+@import "mixins";
 
 // Inline code
 pre,

--- a/styles/_code.scss
+++ b/styles/_code.scss
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 @import 'theme';
+@import 'mixins';
 
 // Inline code
 pre,
@@ -30,9 +31,9 @@ code {
 
 // Code blocks
 pre {
-    background-color: $codeBlockBackground;
+    @include codeBlockTheme($gray2, $white);
+
     border-radius: 16px;
-    color: $codeBlockText;
     display: block;
     margin: 1em 0;
     overflow: auto;

--- a/styles/_code_label.scss
+++ b/styles/_code_label.scss
@@ -16,10 +16,10 @@ limitations under the License.
 
 @import "theme";
 
-$codeLabelClass: "code-label" !default;
+$code-label-class: "code-label" !default;
 
 // Code labels
-.#{$codeLabelClass} {
+.#{$code-label-class} {
     background-color: $gray7;
     border-radius: 16px 16px 0 0;
     color: $gray3;

--- a/styles/_code_label.scss
+++ b/styles/_code_label.scss
@@ -16,33 +16,32 @@ limitations under the License.
 
 @import 'theme';
 
-// Highlight
-mark {
-    background: rgba($highlight, 0.35);
-    border-radius: 8px;
-    color: inherit;
-    display: inline;
-    line-height: calc(1.4em + 1px);
-    padding: 0 2px;
+$codeLabelClass: 'code-label' !default;
 
-    // Ignore any nested highlighting
-    mark {
-        background: none;
-        border-radius: initial;
-        line-height: 1.4em;
-        padding: initial;
+// Code labels
+.#{$codeLabelClass} {
+    background-color: $gray7;
+    border-radius: 16px 16px 0 0;
+    color: $gray3;
+    display: block;
+    font-size: 14px;
+    margin: 1em 0 0;
+    padding: 0.5em 1em;
+    position: relative;
+    text-align: center;
+    z-index: 2;
+
+    + pre {
+        border-radius: 0 0 16px 16px;
+        margin: 0 0 1em;
     }
-}
 
-// Highlights in code
-pre {
-    code {
-        mark {
-            background: rgba($highlightDark, 0.35);
+    // Adjust Prism toolbar
+    + .code-toolbar {
+        margin: 0 0 1em;
 
-            mark {
-                background: none;
-            }
+        pre {
+            border-radius: 0 0 16px 16px;
         }
     }
 }

--- a/styles/_code_label.scss
+++ b/styles/_code_label.scss
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
+@import "theme";
 
-$codeLabelClass: 'code-label' !default;
+$codeLabelClass: "code-label" !default;
 
 // Code labels
 .#{$codeLabelClass} {

--- a/styles/_code_prefix.scss
+++ b/styles/_code_prefix.scss
@@ -42,7 +42,7 @@ pre {
             }
         }
 
-        &.line_numbers {
+        &.line_numbers { /* stylelint-disable-line selector-class-pattern */
             code {
                 ol {
                     li {

--- a/styles/_code_prefix.scss
+++ b/styles/_code_prefix.scss
@@ -49,7 +49,7 @@ pre {
                         margin: 0 0 0 -5px;
 
                         &::before {
-                            border-right: 1px solid rgba($codeBlockText, 0.5);
+                            border-right: 1px solid rgba($white, 0.5);
                             padding-right: 5px;
                         }
                     }

--- a/styles/_code_prefix.scss
+++ b/styles/_code_prefix.scss
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
+@import "theme";
 
 pre {
     &.prefixed {

--- a/styles/_code_prefix.scss
+++ b/styles/_code_prefix.scss
@@ -1,0 +1,60 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'theme';
+
+pre {
+    &.prefixed {
+        code {
+            white-space: normal;
+
+            ol {
+                list-style: none;
+                margin: 0;
+                padding: 0;
+
+                li {
+                    margin: 0;
+                    padding: 0;
+                    white-space: pre;
+
+                    &::before {
+                        content: attr(data-prefix);
+                        display: inline-block;
+                        margin: 0 10px 0 5px;
+                        text-align: right;
+                        user-select: none;
+                    }
+                }
+            }
+        }
+
+        &.line_numbers {
+            code {
+                ol {
+                    li {
+                        margin: 0 0 0 -5px;
+
+                        &::before {
+                            border-right: 1px solid rgba($codeBlockText, 0.5);
+                            padding-right: 5px;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/styles/_code_prism.scss
+++ b/styles/_code_prism.scss
@@ -21,12 +21,12 @@ limitations under the License.
 pre {
     &[class*="language-"] {
         > code {
-            @include prismThemePunctuation($gray9);
-            @include prismThemeComment($gray8);
-            @include prismThemeSelector($blue3);
-            @include prismThemeVariable(#29e3ab);
-            @include prismThemeFunction(#ff4084);
-            @include prismThemeNumber($blueRaspberry);
+            @include prism-theme-punctuation($gray9);
+            @include prism-theme-comment($gray8);
+            @include prism-theme-selector($blue3);
+            @include prism-theme-variable(#29e3ab);
+            @include prism-theme-function(#ff4084);
+            @include prism-theme-number($blue-raspberry);
 
             background: transparent;
 

--- a/styles/_code_prism.scss
+++ b/styles/_code_prism.scss
@@ -1,0 +1,141 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'theme';
+@import 'mixins';
+
+// Prism
+pre {
+    &[class*='language-'] {
+        > code {
+            @include prismThemePunctuation($gray9);
+            @include prismThemeComment($gray8);
+            @include prismThemeSelector($blue3);
+            @include prismThemeVariable(#29e3ab);
+            @include prismThemeFunction(#ff4084);
+            @include prismThemeNumber($blueRaspberry);
+
+            background: transparent;
+
+            &,
+            .token {
+                text-shadow: none;
+            }
+
+            &.language-css,
+            &.style {
+                .token {
+                    &.string {
+                        background: none;
+                    }
+                }
+            }
+
+            .token {
+                background: none;
+                border-radius: 0;
+                display: inline;
+                font-weight: normal;
+                margin: 0;
+                padding: 0;
+
+                &.namespace {
+                    opacity: 0.7;
+                }
+
+                &.operator,
+                &.entity,
+                &.url {
+                    background: none;
+                }
+
+                &.important,
+                &.bold {
+                    font-weight: bold;
+                }
+
+                &.italic {
+                    font-style: italic;
+                }
+            }
+        }
+    }
+
+    // Toolbar
+    .code-toolbar {
+        margin: 1em 0;
+        position: relative;
+
+        > pre {
+            margin: 0;
+        }
+
+        > .toolbar {
+            position: absolute;
+            right: 0.2em;
+            top: 0.3em;
+
+            > .toolbar-item {
+                display: inline-block;
+
+                > a {
+                    text-decoration: none;
+                }
+
+                > button {
+                    background: none;
+                    border: 0;
+                    color: inherit;
+                    font: inherit;
+                    line-height: normal;
+                    overflow: visible;
+                    padding: 0;
+                    user-select: none;
+                }
+
+                > a,
+                > button {
+                    background: $white;
+                    border-radius: 8px;
+                    cursor: pointer;
+                    height: 24px;
+                    padding: 0 8px;
+                    transition: color 0.25s, background 0.25s;
+                    width: auto;
+
+                    &:hover,
+                    &:focus {
+                        background: $blue3;
+                        color: $gray1;
+
+                        span {
+                            color: $white;
+                        }
+                    }
+                }
+
+                > a,
+                > button,
+                > span {
+                    color: $gray3;
+                    font-size: 0.9em;
+                    margin: 0.5em;
+                    padding: 0.1em 8px;
+                }
+            }
+        }
+    }
+}

--- a/styles/_code_prism.scss
+++ b/styles/_code_prism.scss
@@ -14,12 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
-@import 'mixins';
+@import "theme";
+@import "mixins";
 
 // Prism
 pre {
-    &[class*='language-'] {
+    &[class*="language-"] {
         > code {
             @include prismThemePunctuation($gray9);
             @include prismThemeComment($gray8);

--- a/styles/_code_prism.scss
+++ b/styles/_code_prism.scss
@@ -73,68 +73,68 @@ pre {
             }
         }
     }
+}
 
-    // Toolbar
-    .code-toolbar {
-        margin: 1em 0;
-        position: relative;
+// Prism Toolbar
+.code-toolbar {
+    margin: 1em 0;
+    position: relative;
 
-        > pre {
-            margin: 0;
-        }
+    > pre {
+        margin: 0;
+    }
 
-        > .toolbar {
-            position: absolute;
-            right: 0.2em;
-            top: 0.3em;
+    > .toolbar {
+        position: absolute;
+        right: 0.2em;
+        top: 0.3em;
 
-            > .toolbar-item {
-                display: inline-block;
+        > .toolbar-item {
+            display: inline-block;
 
-                > a {
-                    text-decoration: none;
-                }
+            > a {
+                text-decoration: none;
+            }
 
-                > button {
-                    background: none;
-                    border: 0;
-                    color: inherit;
-                    font: inherit;
-                    line-height: normal;
-                    overflow: visible;
-                    padding: 0;
-                    user-select: none;
-                }
+            > button {
+                background: none;
+                border: 0;
+                color: inherit;
+                font: inherit;
+                line-height: normal;
+                overflow: visible;
+                padding: 0;
+                user-select: none;
+            }
 
-                > a,
-                > button {
-                    background: $white;
-                    border-radius: 8px;
-                    cursor: pointer;
-                    height: 24px;
-                    padding: 0 8px;
-                    transition: color 0.25s, background 0.25s;
-                    width: auto;
+            > a,
+            > button {
+                background: $white;
+                border-radius: 8px;
+                cursor: pointer;
+                height: 24px;
+                padding: 0 8px;
+                transition: color 0.25s, background 0.25s;
+                width: auto;
 
-                    &:hover,
-                    &:focus {
-                        background: $blue3;
-                        color: $gray1;
+                &:hover,
+                &:focus {
+                    background: $blue3;
+                    color: $gray1;
 
-                        span {
-                            color: $white;
-                        }
+                    span {
+                        color: $white;
                     }
                 }
+            }
 
-                > a,
-                > button,
-                > span {
-                    color: $gray3;
-                    font-size: 0.9em;
-                    margin: 0.5em;
-                    padding: 0.1em 8px;
-                }
+            > a,
+            > button,
+            > span {
+                color: $gray3;
+                font-size: 0.9em;
+                margin: 0.5em;
+                padding: 0.1em 8px;
             }
         }
     }

--- a/styles/_code_secondary_label.scss
+++ b/styles/_code_secondary_label.scss
@@ -16,33 +16,14 @@ limitations under the License.
 
 @import 'theme';
 
-// Highlight
-mark {
-    background: rgba($highlight, 0.35);
-    border-radius: 8px;
-    color: inherit;
-    display: inline;
-    line-height: calc(1.4em + 1px);
-    padding: 0 2px;
+$codeSecondaryLabelClass: 'secondary-code-label' !default;
 
-    // Ignore any nested highlighting
-    mark {
-        background: none;
-        border-radius: initial;
-        line-height: 1.4em;
-        padding: initial;
-    }
-}
-
-// Highlights in code
+// Code secondary labels
 pre {
     code {
-        mark {
-            background: rgba($highlightDark, 0.35);
-
-            mark {
-                background: none;
-            }
+        .#{$codeSecondaryLabelClass} {
+            color: $blueRaspberry;
+            margin: 0 0 4px;
         }
     }
 }

--- a/styles/_code_secondary_label.scss
+++ b/styles/_code_secondary_label.scss
@@ -16,13 +16,13 @@ limitations under the License.
 
 @import "theme";
 
-$codeSecondaryLabelClass: "secondary-code-label" !default;
+$code-secondary-label-class: "secondary-code-label" !default;
 
 // Code secondary labels
 pre {
     code {
-        .#{$codeSecondaryLabelClass} {
-            color: $blueRaspberry;
+        .#{$code-secondary-label-class} {
+            color: $blue-raspberry;
             margin: 0 0 4px;
         }
     }

--- a/styles/_code_secondary_label.scss
+++ b/styles/_code_secondary_label.scss
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
+@import "theme";
 
-$codeSecondaryLabelClass: 'secondary-code-label' !default;
+$codeSecondaryLabelClass: "secondary-code-label" !default;
 
 // Code secondary labels
 pre {

--- a/styles/_highlight.scss
+++ b/styles/_highlight.scss
@@ -38,7 +38,7 @@ mark {
 pre {
     code {
         mark {
-            background: rgba($highlightDark, 0.35);
+            background: rgba($highlight-dark, 0.35);
 
             mark {
                 background: none;

--- a/styles/_highlight.scss
+++ b/styles/_highlight.scss
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
+@import "theme";
 
 // Highlight
 mark {

--- a/styles/_highlight.scss
+++ b/styles/_highlight.scss
@@ -1,0 +1,35 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'theme';
+
+// Highlight
+mark {
+    background: rgba($highlight, 0.35);
+    border-radius: 8px;
+    color: inherit;
+    display: inline;
+    line-height: calc(1.4em + 1px);
+    padding: 0 2px;
+
+    // Ignore any nested highlighting
+    mark {
+        background: none;
+        border-radius: initial;
+        line-height: 1.4em;
+        padding: initial;
+    }
+}

--- a/styles/_images.scss
+++ b/styles/_images.scss
@@ -1,0 +1,25 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'theme';
+
+// Images
+img {
+    border: solid 2px $gray8;
+    display: block;
+    margin: 1em auto;
+    max-width: 100%;
+}

--- a/styles/_images.scss
+++ b/styles/_images.scss
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
+@import "theme";
 
 // Images
 img {

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -17,7 +17,7 @@ limitations under the License.
 @import 'theme';
 
 @mixin button {
-    background-color: transparent;
+    background: transparent;
     border: 1px solid $blue2;
     border-radius: 3px;
     box-sizing: border-box;
@@ -27,11 +27,19 @@ limitations under the License.
     font-weight: 700;
     line-height: 1;
     padding: 8px 24px;
-    transition: background-color 0.25s ease;
+    transition: background 0.25s ease;
 
-    &:hover,
-    &:focus {
-        background: $blue5;
+    &:disabled {
+        border-color: $gray6;
+        color: $gray6;
+        cursor: not-allowed;
+    }
+
+    &:not(:disabled) {
+        &:hover,
+        &:focus {
+            background: $blue5;
+        }
     }
 }
 

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -43,7 +43,7 @@ limitations under the License.
     }
 }
 
-@mixin codeBlockTheme($background, $text) {
+@mixin code-block-theme($background, $text) {
     background: $background;
     color: $text;
 
@@ -77,7 +77,7 @@ limitations under the License.
     }
 }
 
-@mixin prismThemePunctuation($color) {
+@mixin prism-theme-punctuation($color) {
     &.language-css,
     &.style {
         .token {
@@ -97,7 +97,7 @@ limitations under the License.
     }
 }
 
-@mixin prismThemeComment($color) {
+@mixin prism-theme-comment($color) {
     .token {
         &.comment,
         &.prolog,
@@ -108,7 +108,7 @@ limitations under the License.
     }
 }
 
-@mixin prismThemeSelector($color) {
+@mixin prism-theme-selector($color) {
     .token {
         &.atrule,
         &.property,
@@ -127,7 +127,7 @@ limitations under the License.
     }
 }
 
-@mixin prismThemeVariable($color) {
+@mixin prism-theme-variable($color) {
     .token {
         &.boolean,
         &.attr-name,
@@ -139,7 +139,7 @@ limitations under the License.
     }
 }
 
-@mixin prismThemeFunction($color) {
+@mixin prism-theme-function($color) {
     .token {
         &.attr-value,
         &.function,
@@ -149,7 +149,7 @@ limitations under the License.
     }
 }
 
-@mixin prismThemeNumber($color) {
+@mixin prism-theme-number($color) {
     .token {
         &.regex,
         &.number,
@@ -159,7 +159,7 @@ limitations under the License.
     }
 }
 
-@mixin mQ($size, $limit: "max", $unit: "px") {
+@mixin mq($size, $limit: "max", $unit: "px") {
     @media only screen and (#{$limit}-width: #{$size}#{$unit}) {
         @content;
     }

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -63,7 +63,7 @@ limitations under the License.
             }
         }
 
-        &.line_numbers {
+        &.line_numbers { /* stylelint-disable-line selector-class-pattern */
             code {
                 ol {
                     li {

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -14,14 +14,26 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+@import 'theme';
 
-$smallPhone: 320 !default;
-$phone: 375 !default;
-$largePhone: 425 !default;
-$tablet: 768 !default;
-$desktop: 1024 !default;
-$mediumDesktop: 1220 !default;
-$largeDesktop: 1440 !default;
+@mixin button {
+    background-color: transparent;
+    border: 1px solid $blue2;
+    border-radius: 3px;
+    box-sizing: border-box;
+    color: $blue2;
+    cursor: pointer;
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1;
+    padding: 8px 24px;
+    transition: background-color 0.25s ease;
+
+    &:hover,
+    &:focus {
+        background: $blue5;
+    }
+}
 
 @mixin mQ($size, $limit: 'max', $unit: 'px') {
     @media only screen and (#{$limit}-width: #{$size}#{$unit}) {

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -35,6 +35,122 @@ limitations under the License.
     }
 }
 
+@mixin codeBlockTheme($background, $text) {
+    background: $background;
+    color: $text;
+
+    code {
+        color: $text;
+    }
+
+    // Prefixes
+    &.prefixed {
+        code {
+            ol {
+                li {
+                    &::before {
+                        color: $text;
+                    }
+                }
+            }
+        }
+
+        &.line_numbers {
+            code {
+                ol {
+                    li {
+                        &::before {
+                            border-right-color: rgba($text, 0.5);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@mixin prismThemePunctuation($color) {
+    &.language-css,
+    &.style {
+        .token {
+            &.string {
+                color: $color;
+            }
+        }
+    }
+
+    .token {
+        &.punctuation,
+        &.operator,
+        &.entity,
+        &.url {
+            color: $color;
+        }
+    }
+}
+
+@mixin prismThemeComment($color) {
+    .token {
+        &.comment,
+        &.prolog,
+        &.doctype,
+        &.cdata {
+            color: $color;
+        }
+    }
+}
+
+@mixin prismThemeSelector($color) {
+    .token {
+        &.atrule,
+        &.property,
+        &.tag,
+        &.constant,
+        &.symbol,
+        &.deleted,
+        &.selector,
+        &.char,
+        &.builtin,
+        &.keyword,
+        &.inserted,
+        &.delimiter {
+            color: $color;
+        }
+    }
+}
+
+@mixin prismThemeVariable($color) {
+    .token {
+        &.boolean,
+        &.attr-name,
+        &.color,
+        &.string,
+        &.variable {
+            color: $color;
+        }
+    }
+}
+
+@mixin prismThemeFunction($color) {
+    .token {
+        &.attr-value,
+        &.function,
+        &.class-name {
+            color: $color;
+        }
+    }
+}
+
+@mixin prismThemeNumber($color) {
+    .token {
+        &.regex,
+        &.number,
+        &.important {
+            color: $color;
+        }
+    }
+}
+
 @mixin mQ($size, $limit: 'max', $unit: 'px') {
     @media only screen and (#{$limit}-width: #{$size}#{$unit}) {
         @content;

--- a/styles/_mixins.scss
+++ b/styles/_mixins.scss
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
+@import "theme";
 
 @mixin button {
     background: transparent;
@@ -159,7 +159,7 @@ limitations under the License.
     }
 }
 
-@mixin mQ($size, $limit: 'max', $unit: 'px') {
+@mixin mQ($size, $limit: "max", $unit: "px") {
     @media only screen and (#{$limit}-width: #{$size}#{$unit}) {
         @content;
     }

--- a/styles/_rsvp_button.scss
+++ b/styles/_rsvp_button.scss
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'mixins';
+
+$rsvpButtonClass: 'rsvp' !default;
+
+// RSVP button
+.#{$rsvpButtonClass} {
+    @include button;
+}

--- a/styles/_rsvp_button.scss
+++ b/styles/_rsvp_button.scss
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'mixins';
+@import "mixins";
 
-$rsvpButtonClass: 'rsvp' !default;
+$rsvpButtonClass: "rsvp" !default;
 
 // RSVP button
 .#{$rsvpButtonClass} {

--- a/styles/_rsvp_button.scss
+++ b/styles/_rsvp_button.scss
@@ -16,9 +16,9 @@ limitations under the License.
 
 @import "mixins";
 
-$rsvpButtonClass: "rsvp" !default;
+$rsvp-button-class: "rsvp" !default;
 
 // RSVP button
-.#{$rsvpButtonClass} {
+.#{$rsvp-button-class} {
     @include button;
 }

--- a/styles/_terminal_button.scss
+++ b/styles/_terminal_button.scss
@@ -1,0 +1,24 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'mixins';
+
+$terminalButtonClass: 'terminal' !default;
+
+// Terminal button
+.#{$terminalButtonClass} {
+    @include button;
+}

--- a/styles/_terminal_button.scss
+++ b/styles/_terminal_button.scss
@@ -16,9 +16,9 @@ limitations under the License.
 
 @import "mixins";
 
-$terminalButtonClass: "terminal" !default;
+$terminal-button-class: "terminal" !default;
 
 // Terminal button
-.#{$terminalButtonClass} {
+.#{$terminal-button-class} {
     @include button;
 }

--- a/styles/_terminal_button.scss
+++ b/styles/_terminal_button.scss
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'mixins';
+@import "mixins";
 
-$terminalButtonClass: 'terminal' !default;
+$terminalButtonClass: "terminal" !default;
 
 // Terminal button
 .#{$terminalButtonClass} {

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -71,7 +71,7 @@ $teal3: #7bdeff !default;
 $teal4: #9adef4 !default;
 $teal5: #cfeaf3 !default;
 
-/* Code */
+// Code
 $honeydew: #ffc001 !default;
 $pear: #d7e200 !default;
 $lime: #80d34a !default;
@@ -82,3 +82,6 @@ $blueberry: #2a82ff !default;
 $dragonfruit: #b458fc !default;
 $raspberry: #e681ff !default;
 $strawberry: #ff4c6c !default;
+
+$highlight: #f2c94c !default;
+$highlightDark: #41fff4 !default;

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -15,6 +15,7 @@ limitations under the License.
 */
 
 $black: #000 !default;
+$white: #fff !default;
 
 $gray1: #000c2b !default;
 $gray2: #081b4b !default;
@@ -85,6 +86,9 @@ $strawberry: #ff4c6c !default;
 
 $highlight: #f2c94c !default;
 $highlightDark: #41fff4 !default;
+
+$codeBlockText: $white !default;
+$codeBlockBackground: $gray2 !default;
 
 // Breakpoints
 $smallPhone: 320 !default;

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -1,0 +1,84 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+$black: #000 !default;
+
+$gray1: #000c2b !default;
+$gray2: #081b4b !default;
+$gray3: #24335a !default;
+$gray4: #4d5b7c !default;
+$gray5: #8a96b5 !default;
+$gray6: #aab3ca !default;
+$gray7: #d6dcea !default;
+$gray8: #e3e8f4 !default;
+$gray9: #eff2fb !default;
+$gray10: #f9fafe !default;
+
+$blue1: #002c9b !default;
+$blue2: #0069ff !default;
+$blue3: #4994ff !default;
+$blue4: #92bfff !default;
+$blue5: #c8dfff !default;
+$blue6: #e4f2f9 !default;
+$blueHover: #1253fa !default;
+
+$purple1: #32087a !default;
+$purple2: #6414ee !default;
+$purple3: #9c64ff !default;
+$purple4: #d8c1ff !default;
+$purple5: #eadeff !default;
+
+$fuchsia1: #660066 !default;
+$fuchsia2: #ff1eff !default;
+$fuchsia3: #ff8cff !default;
+$fuchsia4: #ffc0ff !default;
+$fuchsia5: #ffdeff !default;
+
+$red1: #820800 !default;
+$red2: #ff3a2e !default;
+$red3: #ff8c84 !default;
+$red4: #ffbcb7 !default;
+$red5: #ffe2e0 !default;
+
+$orange1: #783200 !default;
+$orange2: #ff720e !default;
+$orange3: #ff9950 !default;
+$orange4: #ffcba6 !default;
+$orange5: #ffebdd !default;
+
+$green1: #005955 !default;
+$green2: #00a099 !default;
+$green3: #33cfc8 !default;
+$green4: #98dfdc !default;
+$green5: #d4efee !default;
+
+$teal1: #00455b !default;
+$teal2: #00bfff !default;
+$teal3: #7bdeff !default;
+$teal4: #9adef4 !default;
+$teal5: #cfeaf3 !default;
+
+/* Code */
+$honeydew: #ffc001 !default;
+$pear: #d7e200 !default;
+$lime: #80d34a !default;
+$greenApple: #00d688 !default;
+$aqua: #01d0c0 !default;
+$blueRaspberry: #00c6ff !default;
+$blueberry: #2a82ff !default;
+$dragonfruit: #b458fc !default;
+$raspberry: #e681ff !default;
+$strawberry: #ff4c6c !default;

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -85,3 +85,12 @@ $strawberry: #ff4c6c !default;
 
 $highlight: #f2c94c !default;
 $highlightDark: #41fff4 !default;
+
+// Breakpoints
+$smallPhone: 320 !default;
+$phone: 375 !default;
+$largePhone: 425 !default;
+$tablet: 768 !default;
+$desktop: 1024 !default;
+$mediumDesktop: 1220 !default;
+$largeDesktop: 1440 !default;

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -87,9 +87,6 @@ $strawberry: #ff4c6c !default;
 $highlight: #f2c94c !default;
 $highlightDark: #41fff4 !default;
 
-$codeBlockText: $white !default;
-$codeBlockBackground: $gray2 !default;
-
 // Breakpoints
 $smallPhone: 320 !default;
 $phone: 375 !default;

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -34,7 +34,7 @@ $blue3: #4994ff !default;
 $blue4: #92bfff !default;
 $blue5: #c8dfff !default;
 $blue6: #e4f2f9 !default;
-$blueHover: #1253fa !default;
+$blue-hover: #1253fa !default;
 
 $purple1: #32087a !default;
 $purple2: #6414ee !default;
@@ -76,22 +76,22 @@ $teal5: #cfeaf3 !default;
 $honeydew: #ffc001 !default;
 $pear: #d7e200 !default;
 $lime: #80d34a !default;
-$greenApple: #00d688 !default;
+$green-apple: #00d688 !default;
 $aqua: #01d0c0 !default;
-$blueRaspberry: #00c6ff !default;
+$blue-raspberry: #00c6ff !default;
 $blueberry: #2a82ff !default;
 $dragonfruit: #b458fc !default;
 $raspberry: #e681ff !default;
 $strawberry: #ff4c6c !default;
 
 $highlight: #f2c94c !default;
-$highlightDark: #41fff4 !default;
+$highlight-dark: #41fff4 !default;
 
 // Breakpoints
-$smallPhone: 320 !default;
+$small-phone: 320 !default;
 $phone: 375 !default;
-$largePhone: 425 !default;
+$large-phone: 425 !default;
 $tablet: 768 !default;
 $desktop: 1024 !default;
-$mediumDesktop: 1220 !default;
-$largeDesktop: 1440 !default;
+$medium-desktop: 1220 !default;
+$large-desktop: 1440 !default;

--- a/styles/_theme.scss
+++ b/styles/_theme.scss
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-$black: #000 !default;
-$white: #fff !default;
+$black: #000000 !default;
+$white: #ffffff !default;
 
+// Grays
 $gray1: #000c2b !default;
 $gray2: #081b4b !default;
 $gray3: #24335a !default;
@@ -28,6 +29,7 @@ $gray8: #e3e8f4 !default;
 $gray9: #eff2fb !default;
 $gray10: #f9fafe !default;
 
+// Blues
 $blue1: #002c9b !default;
 $blue2: #0069ff !default;
 $blue3: #4994ff !default;
@@ -36,36 +38,42 @@ $blue5: #c8dfff !default;
 $blue6: #e4f2f9 !default;
 $blue-hover: #1253fa !default;
 
+// Purples
 $purple1: #32087a !default;
 $purple2: #6414ee !default;
 $purple3: #9c64ff !default;
 $purple4: #d8c1ff !default;
 $purple5: #eadeff !default;
 
+// Fuchsias
 $fuchsia1: #660066 !default;
 $fuchsia2: #ff1eff !default;
 $fuchsia3: #ff8cff !default;
 $fuchsia4: #ffc0ff !default;
 $fuchsia5: #ffdeff !default;
 
+// Reds
 $red1: #820800 !default;
 $red2: #ff3a2e !default;
 $red3: #ff8c84 !default;
 $red4: #ffbcb7 !default;
 $red5: #ffe2e0 !default;
 
+// Oranges
 $orange1: #783200 !default;
 $orange2: #ff720e !default;
 $orange3: #ff9950 !default;
 $orange4: #ffcba6 !default;
 $orange5: #ffebdd !default;
 
+// Greens
 $green1: #005955 !default;
 $green2: #00a099 !default;
 $green3: #33cfc8 !default;
 $green4: #98dfdc !default;
 $green5: #d4efee !default;
 
+// Teals
 $teal1: #00455b !default;
 $teal2: #00bfff !default;
 $teal3: #7bdeff !default;
@@ -84,6 +92,7 @@ $dragonfruit: #b458fc !default;
 $raspberry: #e681ff !default;
 $strawberry: #ff4c6c !default;
 
+// Highlight
 $highlight: #f2c94c !default;
 $highlight-dark: #41fff4 !default;
 

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -17,10 +17,10 @@ limitations under the License.
 @import "theme";
 @import "mixins";
 
-$rootTextStyles: true !default;
+$root-text-styles: true !default;
 
 // Text
-@if $rootTextStyles {
+@if $root-text-styles {
     & {
         color: $gray4;
         font-size: 16px;
@@ -48,7 +48,7 @@ p {
 p {
     line-height: 1.5;
 
-    @include mQ($phone) {
+    @include mq($phone) {
         code {
             word-break: break-all;
         }
@@ -62,7 +62,7 @@ ul {
     margin-bottom: 1.7em;
     padding-left: 2.5em;
 
-    @include mQ($tablet) {
+    @include mq($tablet) {
         padding-left: 0;
     }
 }
@@ -80,8 +80,8 @@ a {
 
     &:hover,
     &:focus {
-        border-bottom-color: $blueHover;
-        color: $blueHover;
+        border-bottom-color: $blue-hover;
+        color: $blue-hover;
     }
 
     code {

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -14,8 +14,8 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'theme';
-@import 'mixins';
+@import "theme";
+@import "mixins";
 
 $rootTextStyles: true !default;
 

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -17,10 +17,14 @@ limitations under the License.
 @import 'theme';
 @import 'mixins';
 
+$rootTextStyles: true !default;
+
 // Text
-& {
-    color: $gray4;
-    font-size: 16px;
+@if $rootTextStyles {
+    & {
+        color: $gray4;
+        font-size: 16px;
+    }
 }
 
 h1,

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import 'theme';
+@import 'breakpoints';
+
+// Text
+& {
+    color: $gray4;
+    font-size: 16px;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6,
+p {
+    margin: 1em 0;
+
+    &:first-child {
+        margin-top: 0;
+    }
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+p {
+    line-height: 1.5;
+
+    @include mQ($phone) {
+        code {
+            word-break: break-all;
+        }
+    }
+}
+
+// Lists
+ol,
+ul {
+    list-style: disc;
+    margin-bottom: 1.7em;
+    padding-left: 2.5em;
+
+    @include mQ($tablet) {
+        padding-left: 0;
+    }
+}
+
+ol {
+    list-style: decimal;
+}
+
+// Links
+a {
+    border-bottom: 1px solid $blue2;
+    color: $blue2;
+    text-decoration: none;
+    transition: color 0.25s, border-bottom-color 0.25s;
+
+    &:hover,
+    &:focus {
+        border-bottom-color: $blueHover;
+        color: $blueHover;
+    }
+
+    code {
+        position: relative;
+        z-index: -1;
+    }
+}
+
+// Quotes
+blockquote {
+    border-left: 4px solid $gray7;
+    color: $gray5;
+    display: block;
+    font-size: 18px;
+    margin: 0 0 1.25em 1.25em;
+    padding: 0 0 0 1.5em;
+
+    a {
+        border-bottom: 1px dotted $gray5;
+        color: $gray5;
+
+        &:hover,
+        &:focus {
+            border-bottom-style: solid;
+        }
+    }
+}

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -15,7 +15,7 @@ limitations under the License.
 */
 
 @import 'theme';
-@import 'breakpoints';
+@import 'mixins';
 
 // Text
 & {

--- a/styles/_youtube.scss
+++ b/styles/_youtube.scss
@@ -1,0 +1,21 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// YouTube embeds
+.youtube {
+    display: block;
+    margin: 1em auto;
+}

--- a/styles/digitalocean/_callouts.scss
+++ b/styles/digitalocean/_callouts.scss
@@ -1,0 +1,40 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '../theme';
+
+// DigitalOcean-usage-specific callout styling
+.callout {
+    &.note {
+        background-color: $green5;
+        color: $green1;
+    }
+
+    &.warning {
+        background-color: $red5;
+        color: $red1;
+    }
+
+    &.info {
+        background-color: $blue5;
+        color: $blue1;
+    }
+
+    &.draft {
+        background-color: $fuchsia4;
+        color: $fuchsia1;
+    }
+}

--- a/styles/digitalocean/_callouts.scss
+++ b/styles/digitalocean/_callouts.scss
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import '../theme';
+@import "../theme";
 
 // DigitalOcean-usage-specific callout styling
 .callout {

--- a/styles/digitalocean/_code_environments.scss
+++ b/styles/digitalocean/_code_environments.scss
@@ -14,13 +14,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import '../theme';
-@import '../mixins';
+@import "../theme";
+@import "../mixins";
 
 // DigitalOcean-usage-specific code environment styling
 pre {
     // Environments use light-mode base
-    &[class*='environment-'] {
+    &[class*="environment-"] {
         > code {
             @include prismThemePunctuation($gray6);
             @include prismThemeComment($gray5);

--- a/styles/digitalocean/_code_environments.scss
+++ b/styles/digitalocean/_code_environments.scss
@@ -22,12 +22,12 @@ pre {
     // Environments use light-mode base
     &[class*="environment-"] {
         > code {
-            @include prismThemePunctuation($gray6);
-            @include prismThemeComment($gray5);
-            @include prismThemeSelector($blue2);
-            @include prismThemeVariable(#08966b);
-            @include prismThemeFunction(#e0276a);
-            @include prismThemeNumber(#225196);
+            @include prism-theme-punctuation($gray6);
+            @include prism-theme-comment($gray5);
+            @include prism-theme-selector($blue2);
+            @include prism-theme-variable(#08966b);
+            @include prism-theme-function(#e0276a);
+            @include prism-theme-number(#225196);
         }
 
         .secondary-code-label {
@@ -44,22 +44,22 @@ pre {
     }
 
     &.environment-local {
-        @include codeBlockTheme($gray8, $gray4);
+        @include code-block-theme($gray8, $gray4);
     }
 
     &.environment-second {
-        @include codeBlockTheme(rgba($blue5, 0.5), $blue1);
+        @include code-block-theme(rgba($blue5, 0.5), $blue1);
     }
 
     &.environment-third {
-        @include codeBlockTheme(rgba($red5, 0.5), $red1);
+        @include code-block-theme(rgba($red5, 0.5), $red1);
     }
 
     &.environment-fourth {
-        @include codeBlockTheme(rgba($green5, 0.5), $green1);
+        @include code-block-theme(rgba($green5, 0.5), $green1);
     }
 
     &.environment-fifth {
-        @include codeBlockTheme(rgba($fuchsia5, 0.5), $fuchsia1);
+        @include code-block-theme(rgba($fuchsia5, 0.5), $fuchsia1);
     }
 }

--- a/styles/digitalocean/_code_environments.scss
+++ b/styles/digitalocean/_code_environments.scss
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@import '../theme';
+@import '../mixins';
+
+// DigitalOcean-usage-specific code environment styling
+pre {
+    // Environments use light-mode base
+    &[class*='environment-'] {
+        > code {
+            @include prismThemePunctuation($gray6);
+            @include prismThemeComment($gray5);
+            @include prismThemeSelector($blue2);
+            @include prismThemeVariable(#08966b);
+            @include prismThemeFunction(#e0276a);
+            @include prismThemeNumber(#225196);
+        }
+
+        .secondary-code-label {
+            color: $gray2;
+        }
+
+        mark {
+            background: rgba($highlight, 0.35);
+
+            mark {
+                background: none;
+            }
+        }
+    }
+
+    &.environment-local {
+        @include codeBlockTheme($gray8, $gray4);
+    }
+
+    &.environment-second {
+        @include codeBlockTheme(rgba($blue5, 0.5), $blue1);
+    }
+
+    &.environment-third {
+        @include codeBlockTheme(rgba($red5, 0.5), $red1);
+    }
+
+    &.environment-fourth {
+        @include codeBlockTheme(rgba($green5, 0.5), $green1);
+    }
+
+    &.environment-fifth {
+        @include codeBlockTheme(rgba($fuchsia5, 0.5), $fuchsia1);
+    }
+}

--- a/styles/digitalocean/index.scss
+++ b/styles/digitalocean/index.scss
@@ -14,5 +14,5 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import 'callouts';
-@import 'code_environments';
+@import "callouts";
+@import "code_environments";

--- a/styles/digitalocean/index.scss
+++ b/styles/digitalocean/index.scss
@@ -1,2 +1,18 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 @import 'callouts';
 @import 'code_environments';

--- a/styles/digitalocean/index.scss
+++ b/styles/digitalocean/index.scss
@@ -1,0 +1,2 @@
+@import 'callouts';
+@import 'code_environments';

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -15,17 +15,17 @@ limitations under the License.
 */
 
 // Standard styling
-@import 'typography';
-@import 'images';
-@import 'code';
+@import "typography";
+@import "images";
+@import "code";
 
 // Plugin styling
-@import 'youtube';
-@import 'rsvp_button';
-@import 'terminal_button';
-@import 'highlight';
-@import 'callouts';
-@import 'code_label';
-@import 'code_prefix';
-@import 'code_prism';
-@import 'code_secondary_label';
+@import "youtube";
+@import "rsvp_button";
+@import "terminal_button";
+@import "highlight";
+@import "callouts";
+@import "code_label";
+@import "code_prefix";
+@import "code_prism";
+@import "code_secondary_label";

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,0 +1,13 @@
+@import 'typography';
+@import 'images';
+@import 'code';
+
+@import 'youtube';
+@import 'rsvp_button';
+@import 'terminal_button';
+@import 'highlight';
+@import 'callouts';
+@import 'code_label';
+@import 'code_prefix';
+@import 'code_prism';
+@import 'code_secondary_label';

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,7 +1,25 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Standard styling
 @import 'typography';
 @import 'images';
 @import 'code';
 
+// Plugin styling
 @import 'youtube';
 @import 'rsvp_button';
 @import 'terminal_button';


### PR DESCRIPTION
## Type of Change

- **Something else:** Styling!

## What issue does this relate to?

N/A

### What should this PR do?

Introduces new SCSS styling for Markdown, exposing the standard styling used for Markdown content across DigitalOcean's Community, including for our Markdown plugins.

### What are the acceptance criteria?

When running the demo server locally, the Markdown output is styled to match the existing usage on the DigitalOcean community. Linting passes for all the added SCSS.