### PR TITLE
Render captions for singleton images with titles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Render captions for singleton images with titles
+
+
 ## v1.1.0 - 3cc7209
 
 - (minor) Provide SCSS styling for Markdown

--- a/README.md
+++ b/README.md
@@ -126,6 +126,31 @@ Set this property to `false` to disable this plugin.
 - `strict` (`boolean`, optional, defaults to `false`): If the end of a comment must be explicitly found.
 </details>
 
+### image_caption
+
+<details>
+<summary>Wrap singleton images that have title text in a figure with a rendered caption.</summary>
+
+**Example Markdown input:**
+
+    ![alt text](test.png "title text")
+
+    ![alt text](test.png "title text _with Markdown_")
+
+**Example HTML output:**
+
+    <figure><img src="test.png" alt="alt text"><figcaption>title text</figcaption></figure>
+
+    <figure><img src="test.png" alt="alt text"><figcaption>title text <em>with Markdown</em></figcaption></figure>
+
+**Options:**
+
+Pass options for this plugin as the `image_caption` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+</details>
+
 ### callout
 
 <details>

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -29,7 +29,7 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 </ul>
 </blockquote>
 <p>Here’s how to include an image with alt text and a title:</p>
-<p><img src="https://assets.digitalocean.com/logos/DO_Logo_horizontal_blue.png" alt="Alt text for screen readers" title="DigitalOcean Logo"></p>
+<figure><img src="https://assets.digitalocean.com/logos/DO_Logo_horizontal_blue.png" alt="Alt text for screen readers"><figcaption>DigitalOcean Logo</figcaption></figure>
 <p>Use horizontal rules to break up long sections:</p>
 <hr>
 <p>Rich transformations are also applied:</p>

--- a/index.js
+++ b/index.js
@@ -27,6 +27,7 @@ const safeObject = require('./util/safe_object');
  * @property {false} [highlight] Disable highlight syntax.
  * @property {false|import('./rules/user_mention').UserMentionOptions} [user_mention] Disable user mentions, or set options for the feature.
  * @property {false|import('./rules/html_comment').HtmlCommentOptions} [html_comment] Disable HTML comment stripping, or set options for the feature.
+ * @property {false} [image_caption] Disable image captions.
  * @property {false|import('./rules/embeds/callout').CalloutOptions} [callout] Disable callout block syntax, or set options for the feature.
  * @property {false|import('./rules/embeds/rsvp_button').RsvpButtonOptions} [rsvp_button] Disable RSVP buttons, or set options for the feature.
  * @property {false|import('./rules/embeds/terminal_button').TerminalButtonOptions} [terminal_button] Disable terminal buttons, or set options for the feature.
@@ -41,7 +42,7 @@ const safeObject = require('./util/safe_object');
  * @property {false|import('./modifiers/fence_secondary_label').FenceSecondaryLabelOptions} [fence_secondary_label] Disable fence secondary labels, or set options for the feature.
  * @property {false|import('./modifiers/fence_environment').FenceEnvironmentOptions} [fence_environment] Disable fence environments, or set options for the feature.
  * @property {false|import('./modifiers/fence_prefix').FencePrefixOptions} [fence_prefix] Disable fence prefixes, or set options for the feature.
- * @property {false} [fence_pre_attrs] Disable fence pre attributes, or set options for the feature.
+ * @property {false} [fence_pre_attrs] Disable fence pre attributes.
  * @property {false|import('./modifiers/fence_classes').FenceClassesOptions} [fence_classes] Disable fence class filtering, or set options for the feature.
  * @property {false|import('./modifiers/heading_id').HeadingIdOptions} [heading_id] Disable Ids on headings, or set options for the feature.
  * @property {false|import('./modifiers/prismjs').PrismJsOptions} [prismjs] Disable Prism highlighting, or set options for the feature.
@@ -68,6 +69,10 @@ module.exports = (md, options) => {
 
     if (optsObj.html_comment !== false) {
         md.use(require('./rules/html_comment'), safeObject(optsObj.html_comment));
+    }
+
+    if (optsObj.image_caption !== false) {
+        md.use(require('./rules/image_caption'), safeObject(optsObj.image_caption));
     }
 
     // Register embeds

--- a/rules/embeds/caniuse.js
+++ b/rules/embeds/caniuse.js
@@ -126,6 +126,8 @@ module.exports = md => {
      * @private
      */
     const canIUseScriptRule = state => {
+        if (state.inlineMode) return;
+
         // Check if we need to inject the script
         if (state.env.caniuse && state.env.caniuse.tokenized && !state.env.caniuse.injected) {
             // Set that we've injected it

--- a/rules/embeds/codepen.js
+++ b/rules/embeds/codepen.js
@@ -132,6 +132,8 @@ module.exports = md => {
      * @private
      */
     const codepenScriptRule = state => {
+        if (state.inlineMode) return;
+
         // Check if we need to inject the script
         if (state.env.codepen && state.env.codepen.tokenized && !state.env.codepen.injected) {
             // Set that we've injected it

--- a/rules/embeds/dns.js
+++ b/rules/embeds/dns.js
@@ -106,6 +106,8 @@ module.exports = md => {
      * @private
      */
     const dnsScriptRule = state => {
+        if (state.inlineMode) return;
+
         // Check if we need to inject the script
         if (state.env.dns && state.env.dns.tokenized && !state.env.dns.injected) {
             // Set that we've injected it

--- a/rules/embeds/glob.js
+++ b/rules/embeds/glob.js
@@ -121,6 +121,8 @@ module.exports = md => {
      * @private
      */
     const globScriptRule = state => {
+        if (state.inlineMode) return;
+
         // Check if we need to inject the script
         if (state.env.glob && state.env.glob.tokenized && !state.env.glob.injected) {
             // Set that we've injected it

--- a/rules/image_caption.js
+++ b/rules/image_caption.js
@@ -1,0 +1,79 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module rules/image_caption
+ */
+
+/**
+ * Wrap singleton images that have title text in a figure with a rendered caption.
+ *
+ * @example
+ * ![alt text](test.png "title text")
+ *
+ * ![alt text](test.png "title text _with Markdown_")
+ *
+ * <figure><img src="test.png" alt="alt text"><figcaption>title text</figcaption></figure>
+ *
+ * <figure><img src="test.png" alt="alt text"><figcaption>title text <em>with Markdown</em></figcaption></figure>
+ *
+ * @type {import('markdown-it').PluginSimple}
+ */
+module.exports = md => {
+    /**
+     * Parsing rule for wrapping singleton image that has a title in a figure with a caption.
+     *
+     * @type {import('markdown-it/lib/parser_core').RuleCore}
+     * @private
+     */
+    const imageCaptionRule = state => {
+        // Iterate over all tokens, except the first and last
+        for (let i = 1; i < state.tokens.length - 1; i += 1) {
+            const token = state.tokens[i];
+
+            // Check if we have an image
+            if (token.type !== 'inline') continue;
+            if (token.children.length !== 1) continue;
+            if (token.children[0].type !== 'image') continue;
+
+            // Check if we have a title
+            const title = token.children[0].attrGet('title');
+            if (!title) continue;
+
+            // Check this is the only item in the paragraph
+            const open = state.tokens[i - 1];
+            const close = state.tokens[i + 1];
+            if (open.type !== 'paragraph_open') continue;
+            if (close.type !== 'paragraph_close') continue;
+
+            // Mutate open/close to become a figure, not a paragraph
+            open.type = 'figure_open';
+            open.tag = 'figure';
+            close.type = 'figure_close';
+            close.tag = 'figure';
+
+            // Inject the caption, treating the title as inline Markdown
+            token.children.push(new state.Token('figcaption_open', 'figcaption', 1));
+            token.children.push(...md.parseInline(title, state.env)[0].children);
+            token.children.push(new state.Token('figcaption_close', 'figcaption', -1));
+            token.children[0].attrs = token.children[0].attrs.filter(([ attr ]) => attr !== 'title');
+        }
+    };
+
+    md.core.ruler.after('inline', 'image_caption', imageCaptionRule);
+};

--- a/rules/image_caption.test.js
+++ b/rules/image_caption.test.js
@@ -1,0 +1,65 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const md = require('markdown-it')().use(require('./image_caption'));
+
+it('handles an image with no alt text and no title text (no caption)', () => {
+    expect(md.render('![](test.png)')).toBe(`<p><img src="test.png" alt=""></p>
+`);
+});
+
+it('handles an image with alt text and no title text (no caption)', () => {
+    expect(md.render('![alt text](test.png)')).toBe(`<p><img src="test.png" alt="alt text"></p>
+`);
+});
+
+it('handles an image with no alt text and unclosed title text (no image)', () => {
+    expect(md.render('![](test.png "title text)')).toBe(`<p>![](test.png &quot;title text)</p>
+`);
+});
+
+it('handles an image with alt text and unclosed title text (no image)', () => {
+    expect(md.render('![alt text](test.png "title text)')).toBe(`<p>![alt text](test.png &quot;title text)</p>
+`);
+});
+
+it('handles an image with no alt text but title text, with surrounding text (no caption)', () => {
+    expect(md.render('![](test.png "title text") hello')).toBe(`<p><img src="test.png" alt="" title="title text"> hello</p>
+`);
+});
+
+it('handles an image with no alt text but title text, with text after (no caption)', () => {
+    expect(md.render('![](test.png "title text")\nhello')).toBe(`<p><img src="test.png" alt="" title="title text">
+hello</p>
+`);
+});
+
+it('handles an image with no alt text but title text', () => {
+    expect(md.render('![](test.png "title text")')).toBe(`<figure><img src="test.png" alt=""><figcaption>title text</figcaption></figure>
+`);
+});
+
+it('handles an image with alt text and title text', () => {
+    expect(md.render('![alt text](test.png "title text")')).toBe(`<figure><img src="test.png" alt="alt text"><figcaption>title text</figcaption></figure>
+`);
+});
+
+it('handles an image with alt text and title text using Markdown', () => {
+    expect(md.render('![alt text](test.png "title text _with Markdown_")')).toBe(`<figure><img src="test.png" alt="alt text"><figcaption>title text <em>with Markdown</em></figcaption></figure>
+`);
+});

--- a/styles/_images.scss
+++ b/styles/_images.scss
@@ -17,9 +17,32 @@ limitations under the License.
 @import "theme";
 
 // Images
-img {
+img,
+figure {
     border: solid 2px $gray8;
+    border-radius: 16px;
     display: block;
-    margin: 1em auto;
+    margin: 1rem auto;
     max-width: 100%;
+}
+
+// Figures
+figure {
+    overflow: hidden;
+    padding: 1rem;
+
+    img {
+        border: none;
+        border-radius: 0;
+        margin: 0 auto;
+    }
+
+    figcaption {
+        border-top: solid 1px $gray8;
+        background: $gray9;
+        font-size: 0.9em;
+        text-align: center;
+        padding: 1rem;
+        margin: 1rem -1rem -1rem;
+    }
 }


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** New image_caption plugin
- **SCSS Styling:** Image styles
- **Something else:** Dev script

## What issue does this relate to?

N/A

### What should this PR do?

Introduces a new plugin that will wrap singleton images (images that are the only element in a paragraph) that have a title in a figure with a figcaption set to be the title (rendered as inline Markdown).

This also includes a couple of tweaks to the dev script to better handle the re-rendering of the content, ensuring embed scripts re-run correctly.

### What are the acceptance criteria?

An image on its own that has a title set will be rendered as a figure with a figcaption matching the title.

An image that has other text surrounding it will not be wrapped in a figure, even if it has a title.

An image without a title set will never be rendered as a figure.