### PR TITLE
Add syntax for expandable details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Add syntax for expandable details
 - (patch) Dependency updates
 - (minor) Add styling for Markdown tables
 - (minor) Add syntax for columns to customise layout

--- a/README.md
+++ b/README.md
@@ -329,6 +329,44 @@ Set this property to `false` to disable this plugin.
 - `innerClassName` (`string`, optional, defaults to `'column'`): Class to use for the inner column container.
 </details>
 
+### details
+
+<details>
+<summary>Add support for expandable details in Markdown, as block syntax.</summary>
+
+To create an expandable details section, use `[details` followed by a summary.
+Content for the expanded section should be provided on lines after, closed with `]` on a new line.
+
+**Example Markdown input:**
+
+    [details This is hidden content
+    Content for inside the expanded section
+    ]
+
+    [details open This section is *open* by default
+    Content for inside the expanded section
+    ]
+
+**Example HTML output:**
+
+    <details>
+    <summary>This is hidden content</summary>
+    <p>Content for inside the expanded section</p>
+    </details>
+
+    <details open>
+    <summary>This section is <em>open</em> by default</summary>
+    <p>Content for inside the expanded section</p>
+    </details>
+
+**Options:**
+
+Pass options for this plugin as the `details` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+</details>
+
 ### glob
 
 <details>

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -208,6 +208,21 @@ Two or more columns adjacent to each other are needed to create a column layout.
 On desktop the columns will be evenly distributed in a single row, on tablets they will wrap naturally, and on mobile they will be in a single stack.
 ]
 
+[details Content can be hidden using `details`.
+Inside the details block you can use any block or inline syntax.
+
+You could hide the solution to a problem:
+```js
+// Write a message to console
+console.log('Hello, world!');
+```
+]
+
+[details open You can also have the details block open by default.
+Pass `open` as the first argument to the summary section to do this.
+
+_You can also pass `closed`, though this is the same as not passing anything before the summary._
+]
 
 ## Step 5 — Embeds
 

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -219,6 +219,19 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 <p>On desktop the columns will be evenly distributed in a single row, on tablets they will wrap naturally, and on mobile they will be in a single stack.</p>
 </div>
 </div>
+<details>
+<summary>Content can be hidden using <code>details</code>.</summary>
+<p>Inside the details block you can use any block or inline syntax.</p>
+<p>You could hide the solution to a problem:</p>
+<pre class="language-javascript"><code><span class="token comment">// Write a message to console</span>
+console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">'Hello, world!'</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+</code></pre>
+</details>
+<details open="">
+<summary>You can also have the details block open by default.</summary>
+<p>Pass <code>open</code> as the first argument to the summary section to do this.</p>
+<p><em>You can also pass <code>closed</code>, though this is the same as not passing anything before the summary.</em></p>
+</details>
 <h2 id="step-5-embeds">Step 5 — Embeds</h2>
 <h3 id="youtube">YouTube</h3>
 <p>Embedding a YouTube video (id, height, width):</p>

--- a/index.js
+++ b/index.js
@@ -33,6 +33,7 @@ const safeObject = require('./util/safe_object');
  * @property {false|import('./rules/embeds/rsvp_button').RsvpButtonOptions} [rsvp_button] Disable RSVP buttons, or set options for the feature.
  * @property {false|import('./rules/embeds/terminal_button').TerminalButtonOptions} [terminal_button] Disable terminal buttons, or set options for the feature.
  * @property {false|import('./rules/embeds/columns').ColumnsOptions} [columns] Disable columns, or set options for the feature.
+ * @property {false} [details] Disable details.
  * @property {false} [glob] Disable glob embeds.
  * @property {false} [dns] Disable DNS lookup embeds.
  * @property {false} [asciinema] Disable Asciinema embeds.
@@ -97,6 +98,10 @@ module.exports = (md, options) => {
 
     if (optsObj.columns !== false) {
         md.use(require('./rules/embeds/columns'), safeObject(optsObj.columns));
+    }
+
+    if (optsObj.details !== false) {
+        md.use(require('./rules/embeds/details'), safeObject(optsObj.details));
     }
 
     if (optsObj.glob !== false) {

--- a/rules/embeds/callout.js
+++ b/rules/embeds/callout.js
@@ -21,6 +21,7 @@ limitations under the License.
  */
 
 const safeObject = require('../../util/safe_object');
+const blockLines = require('../../util/block_lines');
 
 /**
  * @typedef {Object} CalloutOptions
@@ -76,11 +77,7 @@ module.exports = (md, options) => {
         if (silent) return false;
 
         // Get current string to consider (current line to end)
-        const currentLines = Array.from({ length: endLine - startLine }, (_, i) => {
-            const pos = state.bMarks[startLine + i] + state.tShift[startLine + i];
-            const max = state.eMarks[startLine + i];
-            return state.src.substring(pos, max);
-        }).join('\n');
+        const currentLines = blockLines(state, startLine, endLine).join('\n');
 
         // Perform some non-regex checks for speed
         if (currentLines.length < 10) return false; // <$>[a]b<$>

--- a/rules/embeds/columns.js
+++ b/rules/embeds/columns.js
@@ -22,6 +22,7 @@ limitations under the License.
 
 const safeObject = require('../../util/safe_object');
 const blockLines = require('../../util/block_lines');
+const findBlockEmbed = require('../../util/find_block_embed');
 
 /**
  * @typedef {Object} ColumnsOptions
@@ -61,38 +62,6 @@ module.exports = (md, options) => {
     const innerClassName = typeof optsObj.innerClassName === 'string' ? optsObj.innerClassName : 'column';
 
     /**
-     * Find a column block within the given lines, starting at the first line, returning the closing index.
-     *
-     * @param {string[]} lines Lines of Markdown to parse.
-     * @returns {false|number}
-     * @private
-     */
-    const findColumn = lines => {
-        // Perform some basic checks to ensure the column is valid
-        if (lines.length < 3) return false; // [column + content + ]
-        if (lines[0] !== '[column') return false;
-
-        // Attempt to find the closing bracket for this, allowing bracket pairs inside
-        let closingIndex = -1;
-        let open = 0;
-        for (let i = 1; i < lines.length; i += 1) {
-            // If we found an opening bracket that isn't closed on the same line, increase the open count
-            if (lines[i][0] === '[' && lines[i][lines[i].length - 1] !== ']') open += 1;
-
-            // If we found a closing bracket, check if we're at the same level as the opening bracket
-            if (lines[i] === ']') {
-                if (open === 0) {
-                    closingIndex = i;
-                    break;
-                }
-                open -= 1;
-            }
-        }
-
-        return closingIndex === -1 ? false : closingIndex;
-    };
-
-    /**
      * Parsing rule for column markup.
      *
      * @type {import('markdown-it/lib/parser_block').RuleBlock}
@@ -109,7 +78,7 @@ module.exports = (md, options) => {
         const columns = [];
         let nextLine = 0;
         while (true) { // eslint-disable-line no-constant-condition
-            const column = findColumn(currentLines.slice(nextLine));
+            const column = findBlockEmbed(currentLines.slice(nextLine), 'column');
             if (column === false) break;
 
             // Add the column to the list

--- a/rules/embeds/columns.js
+++ b/rules/embeds/columns.js
@@ -21,6 +21,7 @@ limitations under the License.
  */
 
 const safeObject = require('../../util/safe_object');
+const blockLines = require('../../util/block_lines');
 
 /**
  * @typedef {Object} ColumnsOptions
@@ -102,11 +103,7 @@ module.exports = (md, options) => {
         if (silent) return false;
 
         // Get current string to consider (current line to end)
-        const currentLines = Array.from({ length: endLine - startLine }, (_, i) => {
-            const pos = state.bMarks[startLine + i] + state.tShift[startLine + i];
-            const max = state.eMarks[startLine + i];
-            return state.src.substring(pos, max);
-        });
+        const currentLines = blockLines(state, startLine, endLine);
 
         // Find adjacent columns starting from
         const columns = [];

--- a/rules/embeds/details.js
+++ b/rules/embeds/details.js
@@ -24,7 +24,7 @@ const blockLines = require('../../util/block_lines');
 const findBlockEmbed = require('../../util/find_block_embed');
 
 /**
- * Add support for details in Markdown, as block syntax.
+ * Add support for expandable details in Markdown, as block syntax.
  *
  * To create an expandable details section, use `[details` followed by a summary.
  * Content for the expanded section should be provided on lines after, closed with `]` on a new line.

--- a/rules/embeds/details.js
+++ b/rules/embeds/details.js
@@ -1,0 +1,122 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module rules/embeds/details
+ */
+
+const blockLines = require('../../util/block_lines');
+const findBlockEmbed = require('../../util/find_block_embed');
+
+/**
+ * Add support for details in Markdown, as block syntax.
+ *
+ * To create an expandable details section, use `[details` followed by a summary.
+ * Content for the expanded section should be provided on lines after, closed with `]` on a new line.
+ *
+ * @example
+ * [details This is hidden content
+ * Content for inside the expanded section
+ * ]
+ *
+ * [details open This section is *open* by default
+ * Content for inside the expanded section
+ * ]
+ *
+ * <details>
+ * <summary>This is hidden content</summary>
+ * <p>Content for inside the expanded section</p>
+ * </details>
+ *
+ * <details open>
+ * <summary>This section is <em>open</em> by default</summary>
+ * <p>Content for inside the expanded section</p>
+ * </details>
+ *
+ * @type {import('markdown-it').PluginSimple}
+ */
+module.exports = md => {
+    /**
+     * Parsing rule for details markup.
+     *
+     * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
+     */
+    const detailsRule = (state, startLine, endLine, silent) => {
+        // If silent, don't replace
+        if (silent) return false;
+
+        // Get current string to consider (current line to end)
+        const currentLines = blockLines(state, startLine, endLine);
+
+        // Attempt to find the block
+        const block = findBlockEmbed(currentLines, 'details');
+        if (block === false) return false;
+
+        // Check that we have content
+        const parts = currentLines[0].split(' ');
+        if (parts.length === 1) return false;
+        const stateSelection = [ 'open', 'closed' ].includes(parts[1].toLowerCase()) ? parts[1].toLowerCase() : null;
+        if (parts.length === 2 && stateSelection) return false;
+
+        // Create the outer details element
+        const tokenDetailsOpen = state.push('details', 'details', 1);
+        tokenDetailsOpen.block = true;
+        tokenDetailsOpen.map = [ startLine, startLine + block ];
+        if (stateSelection === 'open') tokenDetailsOpen.attrSet('open', '');
+
+        // Create the summary element
+        const tokenSummaryOpen = state.push('summary', 'summary', 1);
+        tokenSummaryOpen.block = true;
+        tokenSummaryOpen.map = [ startLine, startLine + 1 ];
+        tokenSummaryOpen.markup = currentLines[0];
+
+        // Create an inline token for the summary
+        const tokenSummary = state.push('inline', '', 0);
+        tokenSummary.content = parts.slice(stateSelection ? 2 : 1).join(' ');
+        tokenSummary.map = [ startLine, startLine + 1 ];
+        tokenSummary.children = [];
+
+        // Close the summary element
+        const tokenSummaryClose = state.push('summary', 'summary', -1);
+        tokenSummaryClose.block = true;
+
+        // Ensure we only tokenize the content of the column
+        const oldParentType = state.parentType;
+        const oldLineMax = state.lineMax;
+        state.parentType = 'details';
+        state.lineMax = startLine + block;
+
+        // Process the content of the details as block content
+        state.md.block.tokenize(state, startLine + 1, startLine + block);
+
+        // Close the outer details element
+        const tokenContainerClose = state.push('details', 'details', -1);
+        tokenContainerClose.block = true;
+
+        // Move the parser past this content
+        state.parentType = oldParentType;
+        state.lineMax = oldLineMax;
+        state.line = startLine + block + 1;
+
+        // Done
+        return true;
+    };
+
+    md.block.ruler.before('paragraph', 'details', detailsRule);
+};

--- a/rules/embeds/details.test.js
+++ b/rules/embeds/details.test.js
@@ -1,0 +1,111 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const md = require('markdown-it')().use(require('./details'));
+
+it('handles details (not inline)', () => {
+    expect(md.render('[details hello\nworld\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world</p>
+</details>
+`);
+});
+
+it('handles details that is unclosed (no embed)', () => {
+    expect(md.render('[details hello\nworld')).toBe(`<p>[details hello
+world</p>
+`);
+});
+
+it('handles details with no summary (no embed)', () => {
+    expect(md.render('[details\nworld\n]')).toBe(`<p>[details
+world
+]</p>
+`);
+});
+
+it('handles details set to be open', () => {
+    expect(md.render('[details open hello\nworld\n]')).toBe(`<details open="">
+<summary>hello</summary>
+<p>world</p>
+</details>
+`);
+});
+
+it('handles details set to be open with no summary (no embed)', () => {
+    expect(md.render('[details open\nworld\n]')).toBe(`<p>[details open
+world
+]</p>
+`);
+});
+
+it('handles details set to be closed', () => {
+    expect(md.render('[details closed hello\nworld\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world</p>
+</details>
+`);
+});
+
+it('handles details set to be closed with no summary (no embed)', () => {
+    expect(md.render('[details closed\nworld\n]')).toBe(`<p>[details closed
+world
+]</p>
+`);
+});
+
+it('handles details with an extra multi-line bracket pair inside', () => {
+    expect(md.render('[details hello\nworld\n[\ntest\n]\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world
+[
+test
+]</p>
+</details>
+`);
+});
+
+it('handles details with an extra single-line bracket pair inside', () => {
+    expect(md.render('[details hello\nworld\n[test]\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world
+[test]</p>
+</details>
+`);
+});
+
+it('handles details with an unclosed bracket pair inside (no embed)', () => {
+    expect(md.render('[details hello\nworld\n[\ntest\n]')).toBe(`<p>[details hello
+world
+[
+test
+]</p>
+`);
+});
+
+it('handles details blocks', () => {
+    expect(md.render('[details hello\nworld\n\n[details nested hello\nnested world\n]\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world</p>
+<details>
+<summary>nested hello</summary>
+<p>nested world</p>
+</details>
+</details>
+`);
+});

--- a/rules/embeds/glob.js
+++ b/rules/embeds/glob.js
@@ -21,6 +21,7 @@ limitations under the License.
  */
 
 const safeObject = require('../../util/safe_object');
+const blockLines = require('../../util/block_lines');
 
 /**
  * Add support for [glob](https://www.digitalocean.com/community/tools/glob) embeds in Markdown, as block syntax.
@@ -63,11 +64,7 @@ module.exports = md => {
         if (silent) return false;
 
         // Get current string to consider (current line to end)
-        const currentLines = Array.from({ length: endLine - startLine }, (_, i) => {
-            const pos = state.bMarks[startLine + i] + state.tShift[startLine + i];
-            const max = state.eMarks[startLine + i];
-            return state.src.substring(pos, max);
-        }).join('\n');
+        const currentLines = blockLines(state, startLine, endLine).join('\n');
 
         // Perform some non-regex checks for speed
         if (currentLines.length < 10) return false; // [glob a b]

--- a/rules/html_comment.js
+++ b/rules/html_comment.js
@@ -21,6 +21,7 @@ limitations under the License.
  */
 
 const safeObject = require('../util/safe_object');
+const blockLines = require('../util/block_lines');
 
 /**
  * @typedef {Object} HtmlCommentOptions
@@ -94,11 +95,7 @@ module.exports = (md, options) => {
         if (silent) return false;
 
         // Get current string to consider (current line to end)
-        const currentLines = Array.from({ length: endLine - startLine }, (_, i) => {
-            const pos = state.bMarks[startLine + i] + state.tShift[startLine + i];
-            const max = state.eMarks[startLine + i];
-            return state.src.substring(pos, max);
-        }).join('\n');
+        const currentLines = blockLines(state, startLine, endLine).join('\n');
 
         // Perform some non-regex checks for speed
         if (currentLines.length < 4) return false; // <!--

--- a/styles/_details.scss
+++ b/styles/_details.scss
@@ -1,0 +1,66 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+@use "sass:math";
+@import "theme";
+
+// Details
+details {
+    background: $gray10;
+    border-radius: 16px;
+    padding: 1em;
+    margin: 1em 0;
+
+    $size: 7;
+    $border: 2;
+
+    &[open] {
+        summary {
+            border-bottom: 1px solid $gray8;
+            padding: 0 0 1em;
+            margin: 0 0 1em;
+
+            &::after {
+                top: calc(50% - #{math.sqrt($size + $border) * 1px});
+                transform: translateY(-50%) rotate(225deg);
+            }
+        }
+    }
+
+    summary {
+        cursor: pointer;
+        list-style: none;
+        position: relative;
+
+        &::-webkit-details-marker,
+        &::marker {
+            display: none;
+        }
+
+        &::after {
+            content: "";
+            display: block;
+            position: absolute;
+            top: 50%;
+            right: 4px;
+            width: $size * 1px;
+            height: $size * 1px;
+            border: solid $gray5;
+            border-width: 0 ($border * 1px) ($border * 1px) 0;
+            transform: translateY(-50%) rotate(45deg);
+        }
+    }
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -25,6 +25,7 @@ limitations under the License.
 @import "rsvp_button";
 @import "terminal_button";
 @import "columns";
+@import "details";
 @import "highlight";
 @import "callouts";
 @import "code_label";

--- a/util/block_lines.js
+++ b/util/block_lines.js
@@ -1,0 +1,32 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * Get the current lines to consider for Markdown-It block rules.
+ *
+ * @param {import('markdown-it/lib/rules_block/state_block').StateBlock} state State of the parser.
+ * @param {number} startLine Starting line for current parser state.
+ * @param {number} endLine Ending line for current parser state.
+ * @returns {string[]}
+ * @private
+ */
+module.exports = (state, startLine, endLine) => Array.from({ length: endLine - startLine }, (_, i) => {
+    const pos = state.bMarks[startLine + i] + state.tShift[startLine + i];
+    const max = state.eMarks[startLine + i];
+    return state.src.substring(pos, max);
+});

--- a/util/find_block_embed.js
+++ b/util/find_block_embed.js
@@ -1,0 +1,50 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * Find an embed block within the given lines, starting at the first line, returning the closing index.
+ *
+ * @param {string[]} lines Lines of Markdown to parse.
+ * @param {string} type Type of embed to find.
+ * @returns {false|number}
+ * @private
+ */
+module.exports = (lines, type) => {
+    // Perform some basic checks to ensure the block is valid
+    if (lines.length < 3) return false; // [type + content + ]
+    if (lines[0] !== `[${type}` && !lines[0].startsWith(`[${type} `)) return false;
+
+    // Attempt to find the closing bracket for this, allowing bracket pairs inside
+    let closingIndex = -1;
+    let open = 0;
+    for (let i = 1; i < lines.length; i += 1) {
+        // If we found an opening bracket that isn't closed on the same line, increase the open count
+        if (lines[i][0] === '[' && lines[i][lines[i].length - 1] !== ']') open += 1;
+
+        // If we found a closing bracket, check if we're at the same level as the opening bracket
+        if (lines[i] === ']') {
+            if (open === 0) {
+                closingIndex = i;
+                break;
+            }
+            open -= 1;
+        }
+    }
+
+    return closingIndex === -1 ? false : closingIndex;
+};


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Details embed
- **SCSS Styling:** Details

## What issue does this relate to?

N/A

### What should this PR do?

Introduces new syntax similar to columns that allows for HTML `<details>` to be generated. Includes some abstraction of duplicated logic within the plugins. Text on the opening line of the details syntax is treated as inline Markdown for the summary, and content inside the details block is treated as block Markdown for the hidden details content.

### What are the acceptance criteria?

The following syntax can be used to create details blocks that are styled and natively interactive in browsers:

```md
[details This is a details section
This is hidden content

> This is block content inside
]
```