### PR TITLE
Fix block detection with links at start of line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Fix block detection with links at start of line
 
 ## v1.2.0 - e4f2907
 

--- a/rules/embeds/details.test.js
+++ b/rules/embeds/details.test.js
@@ -89,6 +89,33 @@ it('handles details with an extra single-line bracket pair inside', () => {
 `);
 });
 
+it('handles details with an extra single-line bracket pair with text after inside', () => {
+    expect(md.render('[details hello\nworld\n[test] after\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world
+[test] after</p>
+</details>
+`);
+});
+
+it('handles details with nested single-line bracket pairs inside', () => {
+    expect(md.render('[details hello\nworld\n[test [nested]]\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world
+[test [nested]]</p>
+</details>
+`);
+});
+
+it('handles details with nested single-line bracket pairs with text after inside', () => {
+    expect(md.render('[details hello\nworld\n[test [nested]] after\n]')).toBe(`<details>
+<summary>hello</summary>
+<p>world
+[test [nested]] after</p>
+</details>
+`);
+});
+
 it('handles details with an unclosed bracket pair inside (no embed)', () => {
     expect(md.render('[details hello\nworld\n[\ntest\n]')).toBe(`<p>[details hello
 world

--- a/util/find_block_embed.js
+++ b/util/find_block_embed.js
@@ -34,7 +34,16 @@ module.exports = (lines, type) => {
     let open = 0;
     for (let i = 1; i < lines.length; i += 1) {
         // If we found an opening bracket that isn't closed on the same line, increase the open count
-        if (lines[i][0] === '[' && lines[i][lines[i].length - 1] !== ']') open += 1;
+        if (lines[i][0] === '[') {
+            let openLine = 1;
+            for (let j = 1; j < lines[i].length; j += 1) {
+                if (lines[i][j] === '[') openLine += 1;
+                if (lines[i][j] === ']') openLine -= 1;
+                if (openLine === 0) break;
+            }
+
+            if (openLine !== 0) open += 1;
+        }
 
         // If we found a closing bracket, check if we're at the same level as the opening bracket
         if (lines[i] === ']') {


### PR DESCRIPTION
## Type of Change

- **Something else:** Block detection util (for details + columns)

## What issue does this relate to?

N/A

### What should this PR do?

Fixes the detection of embed blocks when a line inside the block started with `[` that was closed with a `]` inside the same line (not at the end of the line).

### What are the acceptance criteria?

A details block or a column that contains a link inside the block should render correctly, not as plain text.

```md
[details Test
[a link](/test)
]
```