### PR TITLE
Expose heading levels in heading_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Expose heading levels in heading_id
 - (minor) Add Wistia embeds
 
 

--- a/README.md
+++ b/README.md
@@ -867,6 +867,7 @@ Each item in the array is an object with the following properties:
 - `content`: The raw Markdown content of the heading (e.g. `My **Heading**`).
 - `text`: The plain-text content of the heading (e.g. `My Heading`).
 - `rendered`: The rendered HTML content of the heading (e.g. `My <strong>Heading</strong>`).
+- `level`: The heading level (e.g. `1`).
 
 **Example Markdown input:**
 

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -67,6 +67,7 @@ const extractText = token => {
  * - `content`: The raw Markdown content of the heading (e.g. `My **Heading**`).
  * - `text`: The plain-text content of the heading (e.g. `My Heading`).
  * - `rendered`: The rendered HTML content of the heading (e.g. `My <strong>Heading</strong>`).
+ * - `level`: The heading level (e.g. `1`).
  *
  * @example
  * # Hello World!
@@ -95,6 +96,10 @@ module.exports = (md, options) => {
         const text = extractText(tokens[idx + 1]);
         const rendered = self.render([ tokens[idx + 1] ], opts, env);
 
+        // Get the level for the heading
+        const level = Number(token.tag.slice(1));
+        if (Number.isNaN(level)) throw new Error(`Invalid heading level: ${token.tag}`);
+
         // Generate an id if not already set
         if (!token.attrs) token.attrs = [];
         let idAttr = token.attrs.find(attr => attr[0] === 'id');
@@ -106,7 +111,7 @@ module.exports = (md, options) => {
         }
 
         // Expose the heading
-        md.headings.push({ slug: idAttr[1], content, text, rendered });
+        md.headings.push({ slug: idAttr[1], content, text, rendered, level });
 
         // Render as normal
         return typeof original === 'function'

--- a/modifiers/heading_id.test.js
+++ b/modifiers/heading_id.test.js
@@ -30,7 +30,48 @@ it('exposes headings in an object after render', () => {
         content: 'Hello World!',
         text: 'Hello World!',
         rendered: 'Hello World!',
+        level: 1,
     } ]);
+});
+
+it('handles multiple headings', () => {
+    md.render('# Hello World!\n\n# This is a test');
+    expect(md.headings).toEqual([
+        {
+            slug: 'hello-world',
+            content: 'Hello World!',
+            text: 'Hello World!',
+            rendered: 'Hello World!',
+            level: 1,
+        },
+        {
+            slug: 'this-is-a-test',
+            content: 'This is a test',
+            text: 'This is a test',
+            rendered: 'This is a test',
+            level: 1,
+        },
+    ]);
+});
+
+it('handles headings of different levels', () => {
+    md.render('# Hello World!\n\n## This is a test');
+    expect(md.headings).toEqual([
+        {
+            slug: 'hello-world',
+            content: 'Hello World!',
+            text: 'Hello World!',
+            rendered: 'Hello World!',
+            level: 1,
+        },
+        {
+            slug: 'this-is-a-test',
+            content: 'This is a test',
+            text: 'This is a test',
+            rendered: 'This is a test',
+            level: 2,
+        },
+    ]);
 });
 
 it('handles inline markdown inside headings', () => {
@@ -40,6 +81,7 @@ it('handles inline markdown inside headings', () => {
         content: 'Hello **World**!',
         text: 'Hello World!',
         rendered: 'Hello <strong>World</strong>!',
+        level: 1,
     } ]);
 });
 
@@ -50,6 +92,7 @@ it('handles inline code inside headings', () => {
         content: 'Hello `World`!',
         text: 'Hello World!',
         rendered: 'Hello <code>World</code>!',
+        level: 1,
     } ]);
 });
 
@@ -61,6 +104,7 @@ it('resets exposed headings between repeat renders', () => {
         content: 'Testing',
         text: 'Testing',
         rendered: 'Testing',
+        level: 1,
     } ]);
 });
 


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** heading_id

## What issue does this relate to?

N/A

### What should this PR do?

Exposes the level for each heading in the `headings` object generated by `heading_id`.

### What are the acceptance criteria?

`level` property is present in each object within `headings` when the `heading_id` plugin is used.