### PR TITLE
Fix styling of inline code within a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Fix styling of inline code within a link
+
 
 ## v1.3.0 - 5daa1ad
 

--- a/dev/client.scss
+++ b/dev/client.scss
@@ -14,6 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+*,
+::after,
+::before {
+    box-sizing: border-box;
+}
+
 html,
 body {
     padding: 0;
@@ -21,6 +27,7 @@ body {
 }
 
 #app {
+    background: #ffffff;
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(384px, 1fr));
 }

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -24,6 +24,7 @@ $root-text-styles: true !default;
     & {
         color: $gray4;
         font-size: 16px;
+        z-index: 0;
     }
 }
 


### PR DESCRIPTION
## Type of Change

- **SCSS Styling:** Root styles

## What issue does this relate to?

N/A

### What should this PR do?

Fixes the styling of inline code within links (as we set a negative z-index on the inline code to render it beneath the link underline) by ensuring that the root of the Markdown container has a z-index of 0 (so that it doesn't also render beneath the root/parents if there was a background set).

### What are the acceptance criteria?

Inline code within links is visible, with the code rendering beneath the underline:

```md
[`test`]()
```

![image](https://user-images.githubusercontent.com/12371363/196548825-bdabe27c-f227-444b-8535-ea8b3e61d4d5.png)
