### PR TITLE
Set position relative on root styles for z-index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Set position relative on root styles for z-index
+
 
 ## v1.3.1 - c3b57ee
 

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -24,6 +24,7 @@ $root-text-styles: true !default;
     & {
         color: $gray4;
         font-size: 16px;
+        position: relative;
         z-index: 0;
     }
 }


### PR DESCRIPTION
## Type of Change

- **SCSS Styling:** Root styles

## What issue does this relate to?

cc #31 

### What should this PR do?

Follow on to #31, and part of the same issue. For usages that aren't in a grid context `position: relative` is required to allow the `z-index` to actually apply.

### What are the acceptance criteria?

`position: relative` is set in root styling, alongside the `z-index`.