### PR TITLE
Remove minified versions of patched Prism files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Remove minified versions of patched Prism files
+
 
 ## v1.3.2 - a395a43
 

--- a/script/prism.js
+++ b/script/prism.js
@@ -87,20 +87,18 @@ fs.writeFileSync(
  */
 const template = source => `const component = Prism => {\n\t${source.replace(/\n/g, '\n\t')}\n};\n\nif (typeof module !== 'undefined' && module.exports) {\n\tmodule.exports = component;\n} else {\n\tcomponent(Prism);\n}\n`;
 
-/**
- * Template to wrap a minified Prism component to export when in a module context.
- *
- * @param {string} source Source code of the component.
- * @returns {string}
- * @private
- */
-const templateMin = source => `const component=Prism=>{${source}};typeof module!='undefined'&&module.exports?module.exports=component:component(Prism);\n`;
-
 // Patch all the components (except autoloader) + plugins to export functions
 const components = getFilesInDir(path.join(base, 'components')).filter(f => f !== autoloader && f.endsWith('.js'));
 const plugins = getFilesInDir(path.join(base, 'plugins')).filter(f => f.endsWith('.js'));
 for (const file of components.concat(plugins)) {
-    fs.writeFileSync(file, (file.endsWith('.min.js') ? templateMin : template)(fs.readFileSync(file, 'utf8').trim()));
+    // Remove minified versions
+    if (file.endsWith('.min.js')) {
+        fs.unlinkSync(file);
+        continue;
+    }
+
+    // Patch the unminified version
+    fs.writeFileSync(file, template(fs.readFileSync(file, 'utf8').trim()));
 }
 
 console.info('Prism patched successfully!');


### PR DESCRIPTION
## Type of Change

- **PrismJS Integration:** Build script

## What issue does this relate to?

N/A

### What should this PR do?

Removes the minified versions of Prism components/plugins during the patch process. This reduces the resulting bundle size when using the plugin with a bundler like Webpack, as the dynamic import in the Prism plugin resolves to less potential files.

### What are the acceptance criteria?

When package is installed, the resulting vendored version of Prism does not contain minified JavaScript components or plugins.