### PR TITLE
Add modifier to enable underline syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Add modifier to enable underline syntax
+
 
 ## v1.3.3 - 21ac6ca
 

--- a/README.md
+++ b/README.md
@@ -659,6 +659,31 @@ Set this property to `false` to disable this plugin.
 _No options are available for this plugin._
 </details>
 
+### underline
+
+<details>
+<summary>Add support for underline markup across all Markdown.</summary>
+
+The syntax for underline text is `__`. E.g. `__hello world__`.
+This replaces the default behaviour for the syntax, which would be bold.
+This syntax is treated as regular inline syntax, similar to bold or italics.
+
+**Example Markdown input:**
+
+    __test__
+
+**Example HTML output:**
+
+    <p><u>test</u></p>
+
+**Options:**
+
+Pass options for this plugin as the `underline` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+</details>
+
 ### fence_label
 
 <details>

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -17,7 +17,7 @@ Before you begin this guide you'll need the following:
 
 ## Step 1 — Basic Markdown
 
-This is _italics_, this is **bold**, and this is ~~strikethrough~~.
+This is _italics_, this is **bold**, this is __underline__, and this is ~~strikethrough~~.
 
 - This is a list item.
 - This list is unordered.

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -9,7 +9,7 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 <li>Familiarity with <a href="https://daringfireball.net/projects/markdown/">Markdown</a></li>
 </ul>
 <h2 id="step-1-basic-markdown">Step 1 — Basic Markdown</h2>
-<p>This is <em>italics</em>, this is <strong>bold</strong>, and this is <s>strikethrough</s>.</p>
+<p>This is <em>italics</em>, this is <strong>bold</strong>, this is <u>underline</u>, and this is <s>strikethrough</s>.</p>
 <ul>
 <li>This is a list item.</li>
 <li>This list is unordered.</li>

--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -42,6 +42,7 @@ const safeObject = require('./util/safe_object');
  * @property {false} [caniuse] Disable CanIUse embeds.
  * @property {false} [youtube] Disable YouTube embeds.
  * @property {false} [wistia] Disable Wistia embeds.
+ * @property {false} [underline] Disable underline syntax.
  * @property {false|import('./modifiers/fence_label').FenceLabelOptions} [fence_label] Disable fence labels, or set options for the feature.
  * @property {false|import('./modifiers/fence_secondary_label').FenceSecondaryLabelOptions} [fence_secondary_label] Disable fence secondary labels, or set options for the feature.
  * @property {false|import('./modifiers/fence_environment').FenceEnvironmentOptions} [fence_environment] Disable fence environments, or set options for the feature.
@@ -138,6 +139,10 @@ module.exports = (md, options) => {
     }
 
     // Register modifiers
+
+    if (optsObj.underline !== false) {
+        md.use(require('./modifiers/underline'), safeObject(optsObj.underline));
+    }
 
     if (optsObj.fence_label !== false) {
         md.use(require('./modifiers/fence_label'), safeObject(optsObj.fence_label));

--- a/modifiers/underline.js
+++ b/modifiers/underline.js
@@ -1,0 +1,60 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module modifiers/underline
+ */
+
+/**
+ * Add support for underline markup across all Markdown.
+ *
+ * The syntax for underline text is `__`. E.g. `__hello world__`.
+ * This replaces the default behaviour for the syntax, which would be bold.
+ * This syntax is treated as regular inline syntax, similar to bold or italics.
+ *
+ * @example
+ * __test__
+ *
+ * <p><u>test</u></p>
+ *
+ * @type {import('markdown-it').PluginSimple}
+ */
+module.exports = md => {
+    /**
+     * Wrap the strong open/close render functions to switch `__` syntax to underline.
+     *
+     * @param {import('markdown-it/lib/renderer').RenderRule} [original] Original render function. Defaults to `renderToken`.
+     * @returns {import('markdown-it/lib/renderer').RenderRule}
+     * @private
+     */
+    const render = original => (tokens, idx, opts, env, self) => {
+        // Get the token
+        const token = tokens[idx];
+
+        // If the token is for bold, and uses the `__` syntax, render as underline
+        if (token.tag === 'strong' && token.markup === '__') token.tag = 'u';
+
+        // Render as normal
+        return typeof original === 'function'
+            ? original(tokens, idx, opts, env, self)
+            : self.renderToken(tokens, idx, opts, env);
+    };
+
+    md.renderer.rules.strong_open = render(md.renderer.rules.strong_open);
+    md.renderer.rules.strong_close = render(md.renderer.rules.strong_close);
+};

--- a/modifiers/underline.test.js
+++ b/modifiers/underline.test.js
@@ -1,0 +1,51 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const md = require('markdown-it')().use(require('./underline'));
+
+it('handles underline syntax isolated', () => {
+    expect(md.renderInline('__test__')).toBe('<u>test</u>');
+});
+
+it('handles underline syntax combined with italic', () => {
+    expect(md.renderInline('__*test*__')).toBe('<u><em>test</em></u>');
+});
+
+it('handles underline syntax combined with bold inside', () => {
+    expect(md.renderInline('__**test**__')).toBe('<u><strong>test</strong></u>');
+});
+
+it('handles underline syntax combined with bold outside', () => {
+    expect(md.renderInline('**__test__**')).toBe('<strong><u>test</u></strong>');
+});
+
+it('handles underline syntax combined with bold first & mismatched', () => {
+    expect(md.renderInline('**__test**__')).toBe('<strong>__test</strong>__');
+});
+
+it('handles underline syntax combined with bold second & mismatched', () => {
+    expect(md.renderInline('__**test__**')).toBe('<u>**test</u>**');
+});
+
+it('handles underline syntax being mixed with end text', () => {
+    expect(md.renderInline('__test__ 123')).toBe('<u>test</u> 123');
+});
+
+it('handles underline syntax being mixed with start text', () => {
+    expect(md.renderInline('123 __test__')).toBe('123 <u>test</u>');
+});


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Underline modifier

## What issue does this relate to?

N/A

### What should this PR do?

Adds a new modifier which wraps the standard rendering for bold text, switching the output HTML to be underlined when the syntax used is `__`.

### What are the acceptance criteria?

Using `__` for text allows it to be underlined. Combining `__` and `**` allows text to be both bold and underlined.