### PR TITLE
Add hash links to headings in heading_id plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,9 @@ Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Add hash links to heading_id plugin
 - (minor) Add syntax for defining settings on images, such as size and alignment
 - (patch) Dependency updates
-- (minor) Add hash links to heading_id plugin
 
 
 ## v1.4.0 - 1d4c368

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See `PUBLISH.md` for instructions on how to publish a new version.
 
 - (minor) Add syntax for defining settings on images, such as size and alignment
 - (patch) Dependency updates
+- (minor) Add hash links to heading_id plugin
 
 
 ## v1.4.0 - 1d4c368

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ Each item in the array is an object with the following properties:
 
 **Example HTML output:**
 
-    <h1 id="hello-world">Hello World!</h1>
+    <h1 id="hello-world"><a class="hash-anchor" href="#hello-world" aria-hidden="true"></a>Hello World!</h1>
 
 **Options:**
 
@@ -908,6 +908,9 @@ Pass options for this plugin as the `heading_id` property of the `do-markdownit`
 Set this property to `false` to disable this plugin.
 
 - `sluggify` (`function(string): string`, optional): Custom function to convert heading content to a slug Id.
+- `hashLink` Set this property to `false` to disable this feature.
+    - `maxLevel` (`number`, optional, defaults to `3`): Max number of heading levels to generate a hash link.
+    - `class` (`string`, optional, defaults to `hash-anchor`): Class name to use on the anchor tag.
 </details>
 
 ### image_settings
@@ -1064,6 +1067,7 @@ Variables listed here should be sorted based on the filename, and then by variab
 | `$code-secondary-label-class` _(string)_ | `secondary-code-label` | The class name used for the `fence_secondary_label` plugin. | [`_code_secondary_label.scss`](./styles/_code_secondary_label.scss) |
 | `$columns-inner-class` _(string)_        | `column`               | The inner class name used for the `columns` plugin.         | [`_columns.scss`](./styles/_columns.scss)                           |
 | `$columns-outer-class` _(string)_        | `columns`              | The outer class name used for the `columns` plugin.         | [`_columns.scss`](./styles/_columns.scss)                           |
+| `$hash-anchor-class` _(string)_          | `hash-anchor`          | The anchor class name used for the `heading_id` plugin.     | [`_heading-id.scss`](./styles/_heading_id.scss)                     |
 | `$rsvp-button-class` _(string)_          | `rsvp`                 | The class name used for the `rsvp_button` plugin.           | [`_rsvp_button.scss`](./styles/_rsvp_button.scss)                   |
 | `$table-wrapper-class` _(string)_        | `table-wrapper`        | The class name used for the `table_wrapper` plugin.         | [`_table_wrapper.scss`](./styles/_table_wrapper.scss)               |
 | `$terminal-button-class` _(string)_      | `terminal`             | The class name used for the `terminal_button` plugin.       | [`_terminal_button.scss`](./styles/_terminal_button.scss)           |

--- a/README.md
+++ b/README.md
@@ -909,7 +909,7 @@ Set this property to `false` to disable this plugin.
 
 - `sluggify` (`function(string): string`, optional): Custom function to convert heading content to a slug Id.
 - `hashLink` Set this property to `false` to disable this feature.
-    - `maxLevel` (`number`, optional, defaults to `3`): Max number of heading levels to generate a hash link.
+    - `maxLevel` (`number`, optional, defaults to `3`): Max heading level to generate hash links for.
     - `class` (`string`, optional, defaults to `hash-anchor`): Class name to use on the anchor tag.
 </details>
 

--- a/dev/render.js
+++ b/dev/render.js
@@ -33,6 +33,9 @@ const md = require('markdown-it')({
     callout: {
         allowedClasses: [ 'note', 'warning', 'info', 'draft' ],
     },
+    heading_id: {
+        hashLink: true,
+    },
 });
 
 /**

--- a/dev/render.js
+++ b/dev/render.js
@@ -33,9 +33,6 @@ const md = require('markdown-it')({
     callout: {
         allowedClasses: [ 'note', 'warning', 'info', 'draft' ],
     },
-    heading_id: {
-        hashLink: true,
-    },
 });
 
 /**

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -1,14 +1,14 @@
-<h1 id="title-header-h1-header">Title Header (H1 header)</h1>
-<h3 id="introduction-h3-header">Introduction (H3 header)</h3>
+<h1 id="title-header-h1-header"><a class="hash-anchor" href="#title-header-h1-header" aria-hidden="true"></a>Title Header (H1 header)</h1>
+<h3 id="introduction-h3-header"><a class="hash-anchor" href="#introduction-h3-header" aria-hidden="true"></a>Introduction (H3 header)</h3>
 <p>This is some placeholder text to show examples of Markdown formatting.
 We have <a href="https://github.com/do-community/do-article-templates">a full article template</a> you can use when writing a DigitalOcean article.
 Please refer to our style and formatting guidelines for more detailed explanations: <a href="https://do.co/style">https://do.co/style</a></p>
-<h2 id="prerequisites-h2-header">Prerequisites (H2 header)</h2>
+<h2 id="prerequisites-h2-header"><a class="hash-anchor" href="#prerequisites-h2-header" aria-hidden="true"></a>Prerequisites (H2 header)</h2>
 <p>Before you begin this guide you’ll need the following:</p>
 <ul>
 <li>Familiarity with <a href="https://daringfireball.net/projects/markdown/">Markdown</a></li>
 </ul>
-<h2 id="step-1-basic-markdown">Step 1 — Basic Markdown</h2>
+<h2 id="step-1-basic-markdown"><a class="hash-anchor" href="#step-1-basic-markdown" aria-hidden="true"></a>Step 1 — Basic Markdown</h2>
 <p>This is <em>italics</em>, this is <strong>bold</strong>, this is <u>underline</u>, and this is <s>strikethrough</s>.</p>
 <ul>
 <li>This is a list item.</li>
@@ -119,7 +119,7 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 </tr>
 </tbody>
 </table>
-</div><h2 id="step-2-code">Step 2 — Code</h2>
+</div><h2 id="step-2-code"><a class="hash-anchor" href="#step-2-code" aria-hidden="true"></a>Step 2 — Code</h2>
 <p>This is <code>inline code</code>. This is a <mark>variable</mark>. This is an <code>in-line code <mark>variable</mark></code>.</p>
 <p>Here’s a configuration file with a label:</p>
 <div class="code-label" title="/etc/nginx/sites-available/default">/etc/nginx/sites-available/default</div>
@@ -186,7 +186,7 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 </li><li data-prefix="9"><span class="token tag"><span class="token tag"><span class="token punctuation">&lt;/</span>html</span><span class="token punctuation">&gt;</span></span>
 </li></ol>
 </code></pre>
-<h2 id="step-3-callouts">Step 3 — Callouts</h2>
+<h2 id="step-3-callouts"><a class="hash-anchor" href="#step-3-callouts" aria-hidden="true"></a>Step 3 — Callouts</h2>
 <p>Here is a note, a warning, some info and a draft note:</p>
 <div class="callout note">
 <p><strong>Note:</strong> Use this for notes on a publication.</p>
@@ -207,7 +207,7 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 </div>
 <p>You can also mention users by username:</p>
 <p><a href="/users/MattIPv4">@MattIPv4</a></p>
-<h2 id="step-4-layout">Step 4 — Layout</h2>
+<h2 id="step-4-layout"><a class="hash-anchor" href="#step-4-layout" aria-hidden="true"></a>Step 4 — Layout</h2>
 <p>Columns allow you to customise the layout of your Markdown:</p>
 <div class="columns">
 <div class="column">
@@ -234,29 +234,29 @@ console<span class="token punctuation">.</span><span class="token function">log<
 <p>Pass <code>open</code> as the first argument to the summary section to do this.</p>
 <p><em>You can also pass <code>closed</code>, though this is the same as not passing anything before the summary.</em></p>
 </details>
-<h2 id="step-5-embeds">Step 5 — Embeds</h2>
-<h3 id="youtube">YouTube</h3>
+<h2 id="step-5-embeds"><a class="hash-anchor" href="#step-5-embeds" aria-hidden="true"></a>Step 5 — Embeds</h2>
+<h3 id="youtube"><a class="hash-anchor" href="#youtube" aria-hidden="true"></a>YouTube</h3>
 <p>Embedding a YouTube video (id, height, width):</p>
 <iframe src="https://www.youtube.com/embed/iom_nhYQIYk" class="youtube" height="225" width="400" style="aspect-ratio: 16/9" frameborder="0" allowfullscreen>
     <a href="https://www.youtube.com/watch?v=iom_nhYQIYk" target="_blank">View YouTube video</a>
 </iframe>
 <p><em>Both the width and height are optional, with the defaults being 480 and 270 respectively.</em><br>
 <em>The width/height set are treated as maximums – the video will scale down to fit the available space, maintaining the aspect ratio.</em></p>
-<h3 id="wistia">Wistia</h3>
+<h3 id="wistia"><a class="hash-anchor" href="#wistia" aria-hidden="true"></a>Wistia</h3>
 <p>Embedding a Wistia video (id, height, width):</p>
 <iframe src="https://fast.wistia.net/embed/iframe/7ld71zbvi6" class="wistia" height="225" width="400" style="aspect-ratio: 16/9" frameborder="0" allowfullscreen>
     <a href="https://fast.wistia.net/embed/iframe/7ld71zbvi6" target="_blank">View Wistia video</a>
 </iframe>
 <p><em>As with the YouTube embed, both the width and height are optional and have the same defaults.</em><br>
 <em>The same behaviour applies to the width/height set, with responsive scaling.</em></p>
-<h3 id="dns">DNS</h3>
+<h3 id="dns"><a class="hash-anchor" href="#dns" aria-hidden="true"></a>DNS</h3>
 <p>Embedding DNS record lookups (hostname, record types…):</p>
 <div data-dns-tool-embed data-dns-domain="digitalocean.com" data-dns-types="A,AAAA">
     <a href="https://www.digitalocean.com/community/tools/dns?domain=digitalocean.com" target="_blank">
         Perform a full DNS lookup for digitalocean.com
     </a>
 </div>
-<h3 id="glob">Glob</h3>
+<h3 id="glob"><a class="hash-anchor" href="#glob" aria-hidden="true"></a>Glob</h3>
 <p>Demonstrating how glob matching works (pattern, tests…):</p>
 <div data-glob-tool-embed data-glob-string="**/*.js" data-glob-test-0="a/b.js" data-glob-test-1="c/d.js" data-glob-test-2="e.jsx" data-glob-test-3="f.md">
     <a href="https://www.digitalocean.com/community/tools/glob?glob=**%2F*.js&tests=a%2Fb.js&tests=c%2Fd.js&tests=e.jsx&tests=f.md" target="_blank">
@@ -269,7 +269,7 @@ console<span class="token punctuation">.</span><span class="token function">log<
         Explore <code>**/*.js</code> as a glob string in our glob testing tool
     </a>
 </div>
-<h3 id="codepen">CodePen</h3>
+<h3 id="codepen"><a class="hash-anchor" href="#codepen" aria-hidden="true"></a>CodePen</h3>
 <p>To provide code examples, you could embed a CodePen with a username and pen ID:</p>
 <p class="codepen" data-height="256" data-theme-id="light" data-default-tab="result" data-user="MattCowley" data-slug-hash="vwPzeX" style="height: 256px; box-sizing: border-box; display: flex; align-items: center; justify-content: center; border: 2px solid; margin: 1em 0; padding: 1em;">
     <span>See the Pen <a href="https://codepen.io/MattCowley/pen/vwPzeX">vwPzeX by MattCowley</a> (<a href="https://codepen.io/MattCowley">@MattCowley</a>) on <a href='https://codepen.io'>CodePen</a>.</span>
@@ -285,7 +285,7 @@ console<span class="token punctuation">.</span><span class="token function">log<
 </ul>
 <p>These flags can be combined in any order to create a custom CodePen embed.
 For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create a dark mode embed that shows the CSS tab by default, with a height of 384px.</p>
-<h3 id="glitch">Glitch</h3>
+<h3 id="glitch"><a class="hash-anchor" href="#glitch" aria-hidden="true"></a>Glitch</h3>
 <p>Alternatively, you may want to embed a code example from Glitch with a project slug:</p>
 <div class="glitch-embed-wrap" style="height: 256px; width: 100%;">
     <iframe src="https://glitch.com/embed/#!/embed/hello-digitalocean?previewSize=100" title="hello-digitalocean on Glitch" allow="geolocation; microphone; camera; midi; encrypted-media; xr-spatial-tracking; fullscreen" allowFullScreen style="height: 100%; width: 100%; border: 0;">
@@ -301,7 +301,7 @@ For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create 
 <li>Pass <code>highlights=...</code> to set lines to highlight when showing the project code (e.g. <code>[glitch hello-digitalocean code path=src/app.jsx highlights=15,25]</code>)</li>
 <li>Pass <code>noattr</code> to remove the author attribution from the embed (e.g. <code>[glitch hello-digitalocean noattr]</code>)</li>
 </ul>
-<h3 id="can-i-use">Can I Use</h3>
+<h3 id="can-i-use"><a class="hash-anchor" href="#can-i-use" aria-hidden="true"></a>Can I Use</h3>
 <p>If you’re writing web-related content, you may want to embed a Can I Use table for a feature:</p>
 <p class="ciu_embed" data-feature="css-grid" data-periods="future_1,current,past_1" data-accessible-colours="false">
     <picture>
@@ -316,20 +316,20 @@ For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create 
 <li>Pass <code>future=...</code> to set how many future browser versions are listed (0-3) (e.g. <code>[caniuse css-grid future=3]</code>)</li>
 <li>Pass <code>accessible</code> to switch to the accessible color scheme by default (e.g. <code>[caniuse css-grid accessible]</code>)</li>
 </ul>
-<h3 id="asciinema">Asciinema</h3>
+<h3 id="asciinema"><a class="hash-anchor" href="#asciinema" aria-hidden="true"></a>Asciinema</h3>
 <p>Embedding a terminal recording from Asciinema (id, cols, rows):</p>
 <script src="https://asciinema.org/a/239367.js" id="asciicast-239367" async data-cols="50" data-rows="20"></script>
 <noscript>
     <a href="https://asciinema.org/a/239367" target="_blank">View asciinema recording</a>
 </noscript>
-<h2 id="step-6-tutorials">Step 6 — Tutorials</h2>
+<h2 id="step-6-tutorials"><a class="hash-anchor" href="#step-6-tutorials" aria-hidden="true"></a>Step 6 — Tutorials</h2>
 <p>Certain features of our Markdown engine are designed specifically for our tutorial content-types.
 These may not be enabled in all contexts in the DigitalOcean community, but are enabled by default in the do-markdownit plugin.</p>
 <p><button data-js="rsvp-button" data-form-id="1234" disabled="disabled" class="rsvp">Marketo RSVP buttons use the `rsvp_button` flag</button></p>
 <button data-js="terminal" data-docker-image="ubuntu:focal" disabled="disabled" class="terminal">
     Terminal buttons are behind the `terminal` flag
 </button>
-<h2 id="conclusion">Conclusion</h2>
+<h2 id="conclusion"><a class="hash-anchor" href="#conclusion" aria-hidden="true"></a>Conclusion</h2>
 <p>Please refer to our <a href="https://do.co/style">writing guidelines</a> for more detailed explanations on our style and formatting.</p>
 <script async defer src="https://do-community.github.io/glob-tool-embed/bundle.js" type="text/javascript" onload="window.GlobToolEmbeds()"></script>
 <script async defer src="https://do-community.github.io/dns-tool-embed/bundle.js" type="text/javascript" onload="window.DNSToolEmbeds()"></script>

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -24,8 +24,14 @@ const safeObject = require('../util/safe_object');
 
 /**
  * @typedef {Object} HeadingIdOptions
- * @property {boolean} [hashLink=false] Generate markup for a hashlink
+ * @property {HashLinkOptions} [hashLink] Override default hash link options.
  * @property {function(string): string} [sluggify] Custom function to convert heading content to a slug Id.
+ */
+
+/**
+ * @typedef {Object} HashLinkOptions
+ * @property {number} maxLevel Max number of heading levels to generate a hash link.
+ * @property {string} class Class name to use on the hash link.
  */
 
 /**
@@ -81,6 +87,24 @@ module.exports = (md, options) => {
     // Get the correct options
     const optsObj = safeObject(options);
 
+    // Set default hashLink options
+    const hashLinkOpts = {
+        class: 'hash-anchor',
+        maxLevel: 3,
+    };
+
+    // Check if hashLink is set in options
+    if (typeof optsObj.hashLink !== 'undefined') {
+        // Check if class is set in hashLink options
+        if (typeof optsObj.hashLink.class !== 'undefined') {
+            hashLinkOpts.class = optsObj.hashLink.class;
+        }
+        // Check if maxLevel is set in hashLink options
+        if (typeof optsObj.hashLink.maxLevel !== 'undefined') {
+            hashLinkOpts.maxLevel = optsObj.hashLink.maxLevel;
+        }
+    }
+
     /**
      * Wrap the heading render function to inject slug Ids and track all headings.
      *
@@ -112,12 +136,12 @@ module.exports = (md, options) => {
         }
 
         // Generate hash link if option is set
-        if (optsObj.hashLink && level <= 3) {
+        if (optsObj.hashLink !== false && level <= hashLinkOpts.maxLevel) {
             // Grab the constructor from current token
             const Token = token.constructor;
             // Generate tokens for hash link
             const linkOpen = new Token('link_open', 'a', 1);
-            linkOpen.attrs = [ [ 'class', 'hash-anchor' ], [ 'href', `#${idAttr[1]}` ], [ 'aria-hidden', true ] ];
+            linkOpen.attrs = [ [ 'class', hashLinkOpts.class ], [ 'href', `#${idAttr[1]}` ], [ 'aria-hidden', true ] ];
             const linkContent = new Token('text', '', 0);
             const linkClose = new Token('link_close', 'a', -1);
 

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -16,8 +16,6 @@ limitations under the License.
 
 'use strict';
 
-const Token = require('markdown-it/lib/token');
-
 /**
  * @module modifiers/heading_id
  */
@@ -26,6 +24,7 @@ const safeObject = require('../util/safe_object');
 
 /**
  * @typedef {Object} HeadingIdOptions
+ * @property {boolean} [hashLink=false] Generate markup for a hashlink
  * @property {function(string): string} [sluggify] Custom function to convert heading content to a slug Id.
  */
 
@@ -112,13 +111,17 @@ module.exports = (md, options) => {
             token.attrs.push(idAttr);
         }
 
-        if (optsObj.hashLink) {
+        // Generate hash link if option is set
+        if (optsObj.hashLink && level <= 3) {
+            // Grab the constructor from current token
+            const Token = token.constructor;
+            // Generate tokens for hash link
             const linkOpen = new Token('link_open', 'a', 1);
             linkOpen.attrs = [ [ 'class', 'hash-anchor' ], [ 'href', `#${idAttr[1]}` ], [ 'aria-hidden', true ] ];
             const linkContent = new Token('text', '', 0);
-            linkContent.content = '#';
             const linkClose = new Token('link_close', 'a', -1);
 
+            // Inject hash link tokens before heading content
             tokens[idx + 1].children.unshift(linkOpen, linkContent, linkClose);
         }
 

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -30,8 +30,8 @@ const safeObject = require('../util/safe_object');
 
 /**
  * @typedef {Object} HashLinkOptions
- * @property {number} maxLevel Max number of heading levels to generate a hash link.
- * @property {string} class Class name to use on the hash link.
+ * @property {number} [maxLevel=3] Max heading level to generate hash links for.
+ * @property {string} [class='hash-anchor'] Class name to use on the hash link.
  */
 
 /**

--- a/modifiers/heading_id.js
+++ b/modifiers/heading_id.js
@@ -16,6 +16,8 @@ limitations under the License.
 
 'use strict';
 
+const Token = require('markdown-it/lib/token');
+
 /**
  * @module modifiers/heading_id
  */
@@ -108,6 +110,16 @@ module.exports = (md, options) => {
                 ? optsObj.sluggify(content)
                 : sluggify(content) ];
             token.attrs.push(idAttr);
+        }
+
+        if (optsObj.hashLink) {
+            const linkOpen = new Token('link_open', 'a', 1);
+            linkOpen.attrs = [ [ 'class', 'hash-anchor' ], [ 'href', `#${idAttr[1]}` ], [ 'aria-hidden', true ] ];
+            const linkContent = new Token('text', '', 0);
+            linkContent.content = '#';
+            const linkClose = new Token('link_close', 'a', -1);
+
+            tokens[idx + 1].children.unshift(linkOpen, linkContent, linkClose);
         }
 
         // Expose the heading

--- a/modifiers/heading_id.test.js
+++ b/modifiers/heading_id.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ limitations under the License.
 const md = require('markdown-it')().use(require('./heading_id'));
 
 it('injects id attributes on headings', () => {
-    expect(md.render('# Hello World!')).toBe(`<h1 id="hello-world">Hello World!</h1>
+    expect(md.render('# Hello World!')).toBe(`<h1 id="hello-world"><a class="hash-anchor" href="#hello-world" aria-hidden="true"></a>Hello World!</h1>
 `);
 });
 
@@ -119,15 +119,42 @@ const mdSluggify = require('markdown-it')().use(require('./heading_id'), {
 });
 
 it('supports a custom sluggify function', () => {
-    expect(mdSluggify.render('# Hello World!')).toBe(`<h1 id="helloworld">Hello World!</h1>
+    expect(mdSluggify.render('# Hello World!')).toBe(`<h1 id="helloworld"><a class="hash-anchor" href="#helloworld" aria-hidden="true"></a>Hello World!</h1>
 `);
 });
 
-const mdHashLink = require('markdown-it')().use(require('./heading_id'), {
-    hashLink: true,
+const mdDisableHashLink = require('markdown-it')().use(require('./heading_id'), {
+    hashLink: false,
 });
 
-it('supports generating a hashlink', () => {
-    expect(mdHashLink.render('# Hello World!')).toBe(`<h1 id="hello-world"><a class="hash-anchor" href="#hello-world" aria-hidden="true"></a>Hello World!</h1>
+it('supports disabling hash links feature', () => {
+    expect(mdDisableHashLink.render('# Hello World!')).toBe(`<h1 id="hello-world">Hello World!</h1>
+`);
+});
+
+const mdMaxHashLinkLevel = require('markdown-it')().use(require('./heading_id'), {
+    hashLink: {
+        maxLevel: 5,
+    },
+});
+
+it('supports adjusting what level of headings generate hash links', () => {
+    expect(mdMaxHashLinkLevel.render('##### Hello World!')).toBe(`<h5 id="hello-world"><a class="hash-anchor" href="#hello-world" aria-hidden="true"></a>Hello World!</h5>
+`);
+});
+
+const mdCustomAnchorClass = require('markdown-it')().use(require('./heading_id'), {
+    hashLink: {
+        class: 'custom-anchor',
+    },
+});
+
+it('supports changing class name for anchor in hash link', () => {
+    expect(mdCustomAnchorClass.render('# Hello World!')).toBe(`<h1 id="hello-world"><a class="custom-anchor" href="#hello-world" aria-hidden="true"></a>Hello World!</h1>
+`);
+});
+
+it('supports rendering heading without anchor above maxLevel', () => {
+    expect(md.render('#### Hello World!')).toBe(`<h4 id="hello-world">Hello World!</h4>
 `);
 });

--- a/modifiers/heading_id.test.js
+++ b/modifiers/heading_id.test.js
@@ -108,6 +108,11 @@ it('resets exposed headings between repeat renders', () => {
     } ]);
 });
 
+it('supports rendering heading without anchor above maxLevel', () => {
+    expect(md.render('#### Hello World!')).toBe(`<h4 id="hello-world">Hello World!</h4>
+`);
+});
+
 const mdSluggify = require('markdown-it')().use(require('./heading_id'), {
     /**
      * Custom sluggify function, forcing lowercase and only allowing alpha chars.
@@ -151,10 +156,5 @@ const mdCustomAnchorClass = require('markdown-it')().use(require('./heading_id')
 
 it('supports changing class name for anchor in hash link', () => {
     expect(mdCustomAnchorClass.render('# Hello World!')).toBe(`<h1 id="hello-world"><a class="custom-anchor" href="#hello-world" aria-hidden="true"></a>Hello World!</h1>
-`);
-});
-
-it('supports rendering heading without anchor above maxLevel', () => {
-    expect(md.render('#### Hello World!')).toBe(`<h4 id="hello-world">Hello World!</h4>
 `);
 });

--- a/modifiers/heading_id.test.js
+++ b/modifiers/heading_id.test.js
@@ -122,3 +122,12 @@ it('supports a custom sluggify function', () => {
     expect(mdSluggify.render('# Hello World!')).toBe(`<h1 id="helloworld">Hello World!</h1>
 `);
 });
+
+const mdHashLink = require('markdown-it')().use(require('./heading_id'), {
+    hashLink: true,
+});
+
+it('supports generating a hashlink', () => {
+    expect(mdHashLink.render('# Hello World!')).toBe(`<h1 id="hello-world"><a class="hash-anchor" href="#hello-world" aria-hidden="true"></a>Hello World!</h1>
+`);
+});

--- a/styles/_heading_id.scss
+++ b/styles/_heading_id.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License") !default;
 you may not use this file except in compliance with the License.
@@ -14,9 +14,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-@import "theme";
+$hash-anchor-class: "hash-anchor" !default;
 
-.hash-anchor {
+.#{$hash-anchor-class} {
     margin-right: 0.5em;
 
     &::before {

--- a/styles/_heading_id.scss
+++ b/styles/_heading_id.scss
@@ -1,7 +1,7 @@
 /*
 Copyright 2022 DigitalOcean
 
-Licensed under the Apache License, Version 2.0 (the "License");
+Licensed under the Apache License, Version 2.0 (the "License") !default;
 you may not use this file except in compliance with the License.
 
 You may obtain a copy of the License at
@@ -14,24 +14,12 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Standard styling
-@import "typography";
-@import "images";
-@import "code";
-@import "tables";
+@import "theme";
 
-// Plugin styling
-@import "youtube";
-@import "wistia";
-@import "rsvp_button";
-@import "terminal_button";
-@import "columns";
-@import "details";
-@import "heading_id";
-@import "highlight";
-@import "callouts";
-@import "code_label";
-@import "code_prefix";
-@import "code_prism";
-@import "code_secondary_label";
-@import "table_wrapper";
+.hash-anchor {
+    margin-right: 0.5em;
+
+    &::before {
+        content: "#";
+    }
+}

--- a/styles/_heading_id.scss
+++ b/styles/_heading_id.scss
@@ -14,10 +14,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+@import "theme";
+
 $hash-anchor-class: "hash-anchor" !default;
 
 .#{$hash-anchor-class} {
+    border-bottom: none;
+    color: $gray5;
     margin-right: 0.5em;
+    text-decoration: none;
+
+    &:hover,
+    &:focus {
+        color: $gray3;
+    }
 
     &::before {
         content: "#";

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -34,3 +34,8 @@ limitations under the License.
 @import "code_prism";
 @import "code_secondary_label";
 @import "table_wrapper";
+
+.hash-anchor {
+    display: inline-block;
+    margin-right: .5em;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Type of Change
- **Markdown-It Plugins:** heading_id - add hash link option

## What issue does this relate to?
n/a

### What should this PR do?
Add an option to add hash links next to headings 1-3

### What are the acceptance criteria?
Turning on option in plugin will generate an anchor next to the heading and clicking it will scroll the page to that section
