### PR TITLE
Add Instagram plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Add Instagram embeds
 
 ## v1.5.1 - 2f1f346
 

--- a/README.md
+++ b/README.md
@@ -708,6 +708,54 @@ Set this property to `false` to disable this plugin.
 _No options are available for this plugin._
 </details>
 
+### instagram
+
+<details>
+<summary>Add support for <a href="https://instagram.com/">Instagram</a> embeds in Markdown, as block syntax.</summary>
+
+The basic syntax is `[instagram <post>]`. E.g. `[instagram https://www.instagram.com/p/CkQuv3_LRgS]`.
+After the post, assorted space-separated flags can be added (in any combination/order):
+
+- Add `caption` to include caption under the post.
+- Add any set of digits to set the width of the embed (in pixels, between 250 and 550, default is 540).
+
+If a width outside the range of 250-550 is selected, a clamped value will be used.
+
+**Example Markdown input:**
+
+    [instagram https://www.instagram.com/p/CkQuv3_LRgS]
+
+    [instagram https://www.instagram.com/p/CkQuv3_LRgS caption 400]
+
+**Example HTML output:**
+
+    <div class="instagram">
+        <blockquote class="instagram-media"
+            data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS"
+            data-instgrm-version="14">
+                <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+        </blockquote>
+    </div>
+
+    <div class="instagram">
+        <blockquote class="instagram-media"
+            style="width: 400px;"
+            data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS"
+            data-instgrm-version="14"
+            data-instgrm-captioned>
+                <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+        </blockquote>
+    </div>
+    <script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+
+**Options:**
+
+Pass options for this plugin as the `instagram` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+</details>
+
 ### underline
 
 <details>

--- a/README.md
+++ b/README.md
@@ -777,7 +777,7 @@ If a width outside the range of 326-550 is selected, a clamped value will be use
                 <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
         </blockquote>
     </div>
-    <script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+    <script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 
 **Options:**
 

--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ After the post, assorted space-separated flags can be added (in any combination/
 
 - Add `caption` to include caption under the post.
 - Add `left`, `center`, or `right` to set the alignment of the embed (default is `left`).
-- Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 326 not enforced here, but provided by Instagram's embed.js).
+- Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 326 as set by Instagram's embed.js).
 
 If two or more alignments are selected, `left` will be preferred, followed by `center`, then `right`.
 

--- a/README.md
+++ b/README.md
@@ -745,15 +745,18 @@ The basic syntax is `[instagram <post>]`. E.g. `[instagram https://www.instagram
 After the post, assorted space-separated flags can be added (in any combination/order):
 
 - Add `caption` to include caption under the post.
-- Add any set of digits to set the width of the embed (in pixels, between 250 and 550, default is 540).
+- Add `left`, `center`, or `right` to set the alignment of the embed (default is `left`).
+- Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 326 not enforced here, but provided by Instagram's embed.js).
 
-If a width outside the range of 250-550 is selected, a clamped value will be used.
+If two or more alignments are selected, `left` will be preferred, followed by `center`, then `right`.
+
+If a width outside the range of 326-550 is selected, a clamped value will be used.
 
 **Example Markdown input:**
 
     [instagram https://www.instagram.com/p/CkQuv3_LRgS]
 
-    [instagram https://www.instagram.com/p/CkQuv3_LRgS caption 400]
+    [instagram https://www.instagram.com/p/CkQuv3_LRgS left caption 400]
 
 **Example HTML output:**
 
@@ -765,7 +768,7 @@ If a width outside the range of 250-550 is selected, a clamped value will be use
         </blockquote>
     </div>
 
-    <div class="instagram">
+    <div class="instagram" align="left">
         <blockquote class="instagram-media"
             style="width: 400px;"
             data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS"
@@ -774,7 +777,7 @@ If a width outside the range of 250-550 is selected, a clamped value will be use
                 <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
         </blockquote>
     </div>
-    <script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+    <script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 
 **Options:**
 

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -332,6 +332,17 @@ Like a few other embeds, you can also pass optional flags to customize the embed
 - Pass `light` or `dark` to switch the theme of the embed (e.g. `[twitter https://twitter.com/MattIPv4/status/1576415168426573825 dark]`)
 - Pass `left`, `center`, or `right` to align the embed (e.g. `[twitter https://twitter.com/MattIPv4/status/1576415168426573825 left]`)
 
+### Instagram
+
+You can also embed a post from Instagram by passing the URL for the post:
+
+[instagram https://www.instagram.com/p/CkQuv3_LRgS]
+
+Like a few other embeds, you can also pass optional flags to customize the embed:
+
+- Pass any integer value (between 250 and 550) to set a custom width for the embed (e.g. `[instagram https://www.instagram.com/p/CkQuv3_LRgS 400]`)
+- Pass `caption` to include caption under the post (e.g. `[instagram https://www.instagram.com/p/CkQuv3_LRgS caption]`)
+
 
 ## Step 6 — Tutorials
 

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -349,7 +349,8 @@ You can also embed a post from Instagram by passing the URL for the post:
 
 Like a few other embeds, you can also pass optional flags to customize the embed:
 
-- Pass any integer value (between 250 and 550) to set a custom width for the embed (e.g. `[instagram https://www.instagram.com/p/CkQuv3_LRgS 400]`)
+- Pass any integer value (between 326 and 550) to set a custom width for the embed (e.g. `[instagram https://www.instagram.com/p/CkQuv3_LRgS 400]`)
+- Add `left`, `center`, or `right` to set the alignment of the embed (default is `left`).
 - Pass `caption` to include caption under the post (e.g. `[instagram https://www.instagram.com/p/CkQuv3_LRgS caption]`)
 
 

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -352,7 +352,8 @@ For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create 
 </div>
 <p>Like a few other embeds, you can also pass optional flags to customize the embed:</p>
 <ul>
-<li>Pass any integer value (between 250 and 550) to set a custom width for the embed (e.g. <code>[instagram https://www.instagram.com/p/CkQuv3_LRgS 400]</code>)</li>
+<li>Pass any integer value (between 326 and 550) to set a custom width for the embed (e.g. <code>[instagram https://www.instagram.com/p/CkQuv3_LRgS 400]</code>)</li>
+<li>Add <code>left</code>, <code>center</code>, or <code>right</code> to set the alignment of the embed (default is <code>left</code>).</li>
 <li>Pass <code>caption</code> to include caption under the post (e.g. <code>[instagram https://www.instagram.com/p/CkQuv3_LRgS caption]</code>)</li>
 </ul>
 <h2 id="step-6-tutorials"><a class="hash-anchor" href="#step-6-tutorials" aria-hidden="true"></a>Step 6 — Tutorials</h2>
@@ -369,4 +370,4 @@ These may not be enabled in all contexts in the DigitalOcean community, but are 
 <script async defer src="https://static.codepen.io/assets/embed/ei.js" type="text/javascript"></script>
 <script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
 <script async defer src="https://platform.twitter.com/widgets.js" type="text/javascript"></script>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -336,6 +336,18 @@ For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create 
 <li>Pass <code>light</code> or <code>dark</code> to switch the theme of the embed (e.g. <code>[twitter https://twitter.com/MattIPv4/status/1576415168426573825 dark]</code>)</li>
 <li>Pass <code>left</code>, <code>center</code>, or <code>right</code> to align the embed (e.g. <code>[twitter https://twitter.com/MattIPv4/status/1576415168426573825 left]</code>)</li>
 </ul>
+<h3 id="instagram"><a class="hash-anchor" href="#instagram" aria-hidden="true"></a>Instagram</h3>
+<p>You can also embed a post from Instagram by passing the URL for the post:</p>
+<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<p>Like a few other embeds, you can also pass optional flags to customize the embed:</p>
+<ul>
+<li>Pass any integer value (between 250 and 550) to set a custom width for the embed (e.g. <code>[instagram https://www.instagram.com/p/CkQuv3_LRgS 400]</code>)</li>
+<li>Pass <code>caption</code> to include caption under the post (e.g. <code>[instagram https://www.instagram.com/p/CkQuv3_LRgS caption]</code>)</li>
+</ul>
 <h2 id="step-6-tutorials"><a class="hash-anchor" href="#step-6-tutorials" aria-hidden="true"></a>Step 6 — Tutorials</h2>
 <p>Certain features of our Markdown engine are designed specifically for our tutorial content-types.
 These may not be enabled in all contexts in the DigitalOcean community, but are enabled by default in the do-markdownit plugin.</p>
@@ -350,3 +362,4 @@ These may not be enabled in all contexts in the DigitalOcean community, but are 
 <script async defer src="https://static.codepen.io/assets/embed/ei.js" type="text/javascript"></script>
 <script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
 <script async defer src="https://platform.twitter.com/widgets.js" type="text/javascript"></script>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -369,4 +369,4 @@ These may not be enabled in all contexts in the DigitalOcean community, but are 
 <script async defer src="https://static.codepen.io/assets/embed/ei.js" type="text/javascript"></script>
 <script async defer src="https://cdn.jsdelivr.net/gh/ireade/caniuse-embed@v1.3.0/public/caniuse-embed.min.js" type="text/javascript"></script>
 <script async defer src="https://platform.twitter.com/widgets.js" type="text/javascript"></script>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>

--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ const safeObject = require('./util/safe_object');
  * @property {false} [youtube] Disable YouTube embeds.
  * @property {false} [wistia] Disable Wistia embeds.
  * @property {false} [twitter] Disable Twitter embeds.
+ * @property {false} [instagram] Disable Instagram embeds.
  * @property {false} [underline] Disable underline syntax.
  * @property {false|import('./modifiers/fence_label').FenceLabelOptions} [fence_label] Disable fence labels, or set options for the feature.
  * @property {false|import('./modifiers/fence_secondary_label').FenceSecondaryLabelOptions} [fence_secondary_label] Disable fence secondary labels, or set options for the feature.
@@ -142,6 +143,10 @@ module.exports = (md, options) => {
 
     if (optsObj.twitter !== false) {
         md.use(require('./rules/embeds/twitter'), safeObject(optsObj.twitter));
+    }
+
+    if (optsObj.instagram !== false) {
+        md.use(require('./rules/embeds/instagram'), safeObject(optsObj.instagram));
     }
 
     // Register modifiers

--- a/rules/embeds/instagram.js
+++ b/rules/embeds/instagram.js
@@ -58,7 +58,7 @@ const safeObject = require('../../util/safe_object');
  *          <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
  *     </blockquote>
  * </div>
- * <script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+ * <script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()></script>
  *
  * @type {import('markdown-it').PluginSimple}
  */
@@ -141,7 +141,7 @@ module.exports = md => {
 
             // Inject the token
             const token = new state.Token('html_block', '', 0);
-            token.content = '<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>\n';
+            token.content = '<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>\n';
             state.tokens.push(token);
         }
     };

--- a/rules/embeds/instagram.js
+++ b/rules/embeds/instagram.js
@@ -1,0 +1,175 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module rules/embeds/instagram
+ */
+
+const safeObject = require('../../util/safe_object');
+
+/**
+ * Add support for [Instagram](https://instagram.com/) embeds in Markdown, as block syntax.
+ *
+ * The basic syntax is `[instagram <post>]`. E.g. `[instagram https://www.instagram.com/p/CkQuv3_LRgS]`.
+ * After the post, assorted space-separated flags can be added (in any combination/order):
+ *
+ * - Add `caption` to include caption under the post.
+ * - Add `left`, `center`, or `right` to set the alignment of the embed (default is `left`).
+ * - Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 540).
+ *
+ * If two or more alignments are selected, `left` will be preferred, followed by `center`, then `right`.
+ *
+ * If a width outside the range of 326-550 is selected, a clamped value will be used.
+ *
+ * @example
+ * [instagram https://www.instagram.com/p/CkQuv3_LRgS]
+ *
+ * [instagram https://www.instagram.com/p/CkQuv3_LRgS left caption 400]
+ *
+ * <div class="instagram">
+ *     <blockquote class="instagram-media"
+ *       data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS"
+ *       data-instgrm-version="14">
+ *          <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+ *     </blockquote>
+ * </div>
+ *
+ * <div class="instagram" align="left">
+ *     <blockquote class="instagram-media"
+ *       style="width: 400px;"
+ *       data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS"
+ *       data-instgrm-version="14"
+ *       data-instgrm-captioned>
+ *          <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+ *     </blockquote>
+ * </div>
+ * <script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+ *
+ * @type {import('markdown-it').PluginSimple}
+ */
+module.exports = md => {
+    /**
+     * Parsing rule for Instagram markup.
+     *
+     * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
+     */
+    const instagramRule = (state, startLine, endLine, silent) => {
+        // If silent, don't replace
+        if (silent) return false;
+
+        // Get current string to consider (just current line)
+        const pos = state.bMarks[startLine] + state.tShift[startLine];
+        const max = state.eMarks[startLine];
+        const currentLine = state.src.substring(pos, max);
+
+        // Perform some non-regex checks for speed
+        if (currentLine.length < 13) return false; // [instagram a/p/b]
+        if (currentLine.slice(0, 11) !== '[instagram ') return false;
+        if (currentLine[currentLine.length - 1] !== ']') return false;
+
+        // Check for Instagram match
+        // https://www.instagram.com/p/<post> (treat everything prior to <post> as optional, ish)
+        const alignment = [ 'left', 'center', 'right' ];
+        const match = currentLine.match(`^\\[instagram (?:(?:(?:(?:https?:)?\\/\\/)?(?:www\\.)?instagram\\.com)?\\/)?(?:(?:\\w+)\\/)?(\\w+)((?: (?:${alignment.join('|')}|caption|\\d+))*)\\]$`);
+        if (!match) return false;
+
+        // Get the user
+        const post = match[1];
+        if (!post) return false;
+
+        // Get the raw flags
+        const flags = match[2];
+
+        // Get the width
+        const widthMatch = flags.match(/\d+/);
+        const width = widthMatch ? Math.max(Math.min(Number(widthMatch[0]), 550), 326) : 0;
+
+        // Get the caption
+        const showCaption = flags.includes('caption');
+
+        // Get the alignment
+        const align = alignment.find(t => flags.includes(t)) || 'center';
+
+        // Update the pos for the parser
+        state.line = startLine + 1;
+
+        // Add token to state
+        const token = state.push('instagram', 'instagram', 0);
+        token.block = true;
+        token.markup = match[0];
+        token.instagram = { post, width, showCaption, align };
+
+        // Track that we need the script
+        state.env.instagram = safeObject(state.env.instagram);
+        state.env.instagram.tokenized = true;
+
+        // Done
+        return true;
+    };
+
+    md.block.ruler.before('paragraph', 'instagram', instagramRule);
+
+    /**
+     * Parsing rule to inject the Instagram script.
+     *
+     * @type {import('markdown-it').RuleCore}
+     * @private
+     */
+    const instagramScriptRule = state => {
+        if (state.inlineMode) return;
+
+        // Check if we need to inject the script
+        if (state.env.instagram && state.env.instagram.tokenized && !state.env.instagram.injected) {
+            // Set that we've injected it
+            state.env.instagram.injected = true;
+
+            // Inject the token
+            const token = new state.Token('html_block', '', 0);
+            token.content = '<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>\n';
+            state.tokens.push(token);
+        }
+    };
+
+    md.core.ruler.push('instagram_script', instagramScriptRule);
+
+    /**
+     * Rendering rule for Instagram markup.
+     *
+     * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
+     */
+    md.renderer.rules.instagram = (tokens, index) => {
+        const token = tokens[index];
+
+        // Construct the attrs
+        const attrCaption = token.instagram.showCaption ? ' data-instgrm-captioned' : '';
+        const attrAlign = token.instagram.align !== 'center' ? ` align="${md.utils.escapeHtml(token.instagram.align)}"` : '';
+
+        // Escape some HTML
+        const post = md.utils.escapeHtml(token.instagram.post);
+        const width = md.utils.escapeHtml(token.instagram.width);
+
+        // Return the HTML
+        return `<div class="instagram"${attrAlign}>
+    <blockquote class="instagram-media" ${width ? `style="width: ${width}px;" ` : ''}data-instgrm-permalink="https://www.instagram.com/p/${post}" data-instgrm-version="14"${attrCaption}>
+        <a href="https://instagram.com/p/${post}">View post</a>
+    </blockquote>
+</div>\n`;
+    };
+};

--- a/rules/embeds/instagram.js
+++ b/rules/embeds/instagram.js
@@ -30,7 +30,7 @@ const safeObject = require('../../util/safe_object');
  *
  * - Add `caption` to include caption under the post.
  * - Add `left`, `center`, or `right` to set the alignment of the embed (default is `left`).
- * - Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 540).
+ * - Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 326 not enforced here, but provided by Instagram's embed.js).
  *
  * If two or more alignments are selected, `left` will be preferred, followed by `center`, then `right`.
  *
@@ -58,7 +58,7 @@ const safeObject = require('../../util/safe_object');
  *          <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
  *     </blockquote>
  * </div>
- * <script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+ * <script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
  *
  * @type {import('markdown-it').PluginSimple}
  */
@@ -79,7 +79,7 @@ module.exports = md => {
         const currentLine = state.src.substring(pos, max);
 
         // Perform some non-regex checks for speed
-        if (currentLine.length < 13) return false; // [instagram a/p/b]
+        if (currentLine.length < 13) return false; // [instagram a]
         if (currentLine.slice(0, 11) !== '[instagram ') return false;
         if (currentLine[currentLine.length - 1] !== ']') return false;
 
@@ -141,7 +141,7 @@ module.exports = md => {
 
             // Inject the token
             const token = new state.Token('html_block', '', 0);
-            token.content = '<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>\n';
+            token.content = '<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>\n';
             state.tokens.push(token);
         }
     };

--- a/rules/embeds/instagram.js
+++ b/rules/embeds/instagram.js
@@ -30,7 +30,7 @@ const safeObject = require('../../util/safe_object');
  *
  * - Add `caption` to include caption under the post.
  * - Add `left`, `center`, or `right` to set the alignment of the embed (default is `left`).
- * - Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 326 not enforced here, but provided by Instagram's embed.js).
+ * - Add any set of digits to set the width of the embed (in pixels, between 326 and 550, default is 326 as set by Instagram's embed.js).
  *
  * If two or more alignments are selected, `left` will be preferred, followed by `center`, then `right`.
  *

--- a/rules/embeds/instagram.test.js
+++ b/rules/embeds/instagram.test.js
@@ -1,0 +1,229 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const md = require('markdown-it')().use(require('./instagram'));
+
+it('handles instagram embeds (not inline)', () => {
+    expect(md.render('[instagram https://www.instagram.com/p/CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with no link (no embed)', () => {
+    expect(md.render('[instagram  ]')).toBe(`<p>[instagram  ]</p>
+`);
+});
+
+it('handles instagram embeds that are unclosed (no embed)', () => {
+    expect(md.render('[instagram https://www.instagram.com/p/CkQuv3_LRg')).toBe(`<p>[instagram https://www.instagram.com/p/CkQuv3_LRg</p>
+`);
+});
+
+it('handles instagram embeds with http', () => {
+    expect(md.render('[instagram http://instagram.com/p/CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with no https:', () => {
+    expect(md.render('[instagram //instagram.com/p/CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with no https://', () => {
+    expect(md.render('[instagram instagram.com/p/CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with https://www.instagram.com', () => {
+    expect(md.render('[instagram https://www.instagram.com/p/CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with www.instagram.com', () => {
+    expect(md.render('[instagram www.instagram.com/p/CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with only post id', () => {
+    expect(md.render('[instagram CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with only post id and a leading slash', () => {
+    expect(md.render('[instagram /CkQuv3_LRgS]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with a custom width', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS 400]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" style="width: 400px;" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with a custom width that is too large', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS 1000]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" style="width: 550px;" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with a custom width that is too small', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS 100]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" style="width: 326px;" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with the caption flag', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS caption]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14" data-instgrm-captioned>
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with the left alignment', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS left]')).toBe(`<div class="instagram" align="left">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with the right alignment', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS right]')).toBe(`<div class="instagram" align="right">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with the center alignment', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS center]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with the left and right alignment (preferring left)', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS right left]')).toBe(`<div class="instagram" align="left">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with the center and right alignment (preferring center)', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS right center]')).toBe(`<div class="instagram">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with the left, center and right alignment (preferring left)', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS center right left]')).toBe(`<div class="instagram" align="left">
+    <blockquote class="instagram-media" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14">
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds with multiple flags combined (caption, left alignment, custom width)', () => {
+    expect(md.render('[instagram https://instagram.com/p/CkQuv3_LRgS caption left 400]')).toBe(`<div class="instagram" align="left">
+    <blockquote class="instagram-media" style="width: 400px;" data-instgrm-permalink="https://www.instagram.com/p/CkQuv3_LRgS" data-instgrm-version="14" data-instgrm-captioned>
+        <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
+    </blockquote>
+</div>
+<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+`);
+});
+
+it('handles instagram embeds attempting html injection', () => {
+    expect(md.render('[instagram https://instagram.com/<script>alert();</script>/12345]')).toBe(`<p>[instagram https://instagram.com/&lt;script&gt;alert();&lt;/script&gt;/12345]</p>
+`);
+});
+
+it('handles instagram embeds attempting url manipulation', () => {
+    expect(md.render('[instagram https://instagram.com/../12345]')).toBe(`<p>[instagram https://instagram.com/../12345]</p>
+`);
+});

--- a/rules/embeds/instagram.test.js
+++ b/rules/embeds/instagram.test.js
@@ -24,7 +24,7 @@ it('handles instagram embeds (not inline)', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -44,7 +44,7 @@ it('handles instagram embeds with http', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -54,7 +54,7 @@ it('handles instagram embeds with no https:', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -64,7 +64,7 @@ it('handles instagram embeds with no https://', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -74,7 +74,7 @@ it('handles instagram embeds with https://www.instagram.com', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -84,7 +84,7 @@ it('handles instagram embeds with www.instagram.com', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -94,7 +94,7 @@ it('handles instagram embeds with only post id', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -104,7 +104,7 @@ it('handles instagram embeds with only post id and a leading slash', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -114,7 +114,7 @@ it('handles instagram embeds with a custom width', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -124,7 +124,7 @@ it('handles instagram embeds with a custom width that is too large', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -134,7 +134,7 @@ it('handles instagram embeds with a custom width that is too small', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -144,7 +144,7 @@ it('handles instagram embeds with the caption flag', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -154,7 +154,7 @@ it('handles instagram embeds with the left alignment', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -164,7 +164,7 @@ it('handles instagram embeds with the right alignment', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -174,7 +174,7 @@ it('handles instagram embeds with the center alignment', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -184,7 +184,7 @@ it('handles instagram embeds with the left and right alignment (preferring left)
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -194,7 +194,7 @@ it('handles instagram embeds with the center and right alignment (preferring cen
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -204,7 +204,7 @@ it('handles instagram embeds with the left, center and right alignment (preferri
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 
@@ -214,7 +214,7 @@ it('handles instagram embeds with multiple flags combined (caption, left alignme
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="//www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
 `);
 });
 

--- a/rules/embeds/instagram.test.js
+++ b/rules/embeds/instagram.test.js
@@ -24,7 +24,7 @@ it('handles instagram embeds (not inline)', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -44,7 +44,7 @@ it('handles instagram embeds with http', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -54,7 +54,7 @@ it('handles instagram embeds with no https:', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -64,7 +64,7 @@ it('handles instagram embeds with no https://', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -74,7 +74,7 @@ it('handles instagram embeds with https://www.instagram.com', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -84,7 +84,7 @@ it('handles instagram embeds with www.instagram.com', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -94,7 +94,7 @@ it('handles instagram embeds with only post id', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -104,7 +104,7 @@ it('handles instagram embeds with only post id and a leading slash', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -114,7 +114,7 @@ it('handles instagram embeds with a custom width', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -124,7 +124,7 @@ it('handles instagram embeds with a custom width that is too large', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -134,7 +134,7 @@ it('handles instagram embeds with a custom width that is too small', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -144,7 +144,7 @@ it('handles instagram embeds with the caption flag', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -154,7 +154,7 @@ it('handles instagram embeds with the left alignment', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -164,7 +164,7 @@ it('handles instagram embeds with the right alignment', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -174,7 +174,7 @@ it('handles instagram embeds with the center alignment', () => {
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -184,7 +184,7 @@ it('handles instagram embeds with the left and right alignment (preferring left)
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -194,7 +194,7 @@ it('handles instagram embeds with the center and right alignment (preferring cen
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -204,7 +204,7 @@ it('handles instagram embeds with the left, center and right alignment (preferri
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 
@@ -214,7 +214,7 @@ it('handles instagram embeds with multiple flags combined (caption, left alignme
         <a href="https://instagram.com/p/CkQuv3_LRgS">View post</a>
     </blockquote>
 </div>
-<script async defer src="https://www.instagram.com/embed.js" type="text/javascript"></script>
+<script async defer src="https://www.instagram.com/embed.js" type="text/javascript" onload="window.instgrm && window.instgrm.Embeds.process()"></script>
 `);
 });
 

--- a/styles/_instagram.scss
+++ b/styles/_instagram.scss
@@ -20,7 +20,7 @@ limitations under the License.
     }
 
     &[align="left"] {
-        .instagram-media{
+        .instagram-media {
             margin-left: 0 !important;
         }
     }

--- a/styles/_instagram.scss
+++ b/styles/_instagram.scss
@@ -1,0 +1,33 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+.instagram {
+    .instagram-media {
+        margin: 1rem auto !important;
+    }
+
+    &[align="left"] {
+        .instagram-media{
+            margin-left: 0 !important;
+        }
+    }
+
+    &[align="right"] {
+        .instagram-media {
+            margin-right: 0 !important;
+        }
+    }
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -28,6 +28,7 @@ limitations under the License.
 @import "columns";
 @import "details";
 @import "twitter";
+@import "instagram";
 @import "heading_id";
 @import "highlight";
 @import "callouts";


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Instagram

## What issue does this relate to?
N/A

### What should this PR do?
This introduces a new plugin with syntax for embedding posts from Instagram in Markdown. The syntax is [instagram <URL>], following the same pattern as many of our other embed plugins.

Like other embed plugins, it also supports optional flags after the URL, in this case for setting the alignment (left/center/right), and the width (between 326 and 550, per Instagram's docs).

### What are the acceptance criteria?
The new syntax works as expected, allowing the user to embed Instagram posts in Markdown content, optionally changing the post alignment or setting a custom width for the post.
