### PR TITLE
Add Image comparison plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Add Image Compare embeds
 - (minor) Add Vimeo embeds
 
 

--- a/README.md
+++ b/README.md
@@ -736,6 +736,36 @@ Set this property to `false` to disable this plugin.
 _No options are available for this plugin._
 </details>
 
+### image_compare
+
+<details>
+<summary>Add support for Image Comparison in Markdown, as block syntax.</summary>
+
+The basic syntax is `[imageCompare <url1> <url2>]`. E.g., `[imageCompare https://rb.gy/jykhuo https://rb.gy/zt5afg]`.
+Height and width can optionally be set using `[vimeo <url1> <url2> [height] [width]]`. E.g., `[imageCompare https://rb.gy/jykhuo https://rb.gy/zt5afg 500 560]`.
+The default value for height is 500 and for width is 500.
+
+**Example Markdown input:**
+
+    [imageCompare https://rb.gy/jykhuo https://rb.gy/zt5afg]
+
+**Example HTML output:**
+
+    <div class="imageCompare" style="--value:50%; height: 500px; width: 500px;">
+        <img class="image-left" src="https://rb.gy/jykhuo" alt="Image left"/>
+        <img class="image-right" src="https://rb.gy/zt5afg" alt="Image right"/>
+        <input type="range" class="control" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--value', `${this.value}%`)" />
+        <svg class="control-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></svg>
+    </div>
+
+**Options:**
+
+Pass options for this plugin as the `image_compare` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+</details>
+
 ### underline
 
 <details>

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -341,6 +341,13 @@ Like a few other embeds, you can also pass optional flags to customize the embed
 - Pass `light` or `dark` to switch the theme of the embed (e.g. `[twitter https://twitter.com/MattIPv4/status/1576415168426573825 dark]`)
 - Pass `left`, `center`, or `right` to align the embed (e.g. `[twitter https://twitter.com/MattIPv4/status/1576415168426573825 left]`)
 
+### Image compare
+
+Compare two images side by side. (url1, url2, height, width)
+
+[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg]
+
+_Both the width and height are optional, with the defaults being 500 for both._\
 
 ## Step 6 — Tutorials
 

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -343,6 +343,15 @@ For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create 
 <li>Pass <code>light</code> or <code>dark</code> to switch the theme of the embed (e.g. <code>[twitter https://twitter.com/MattIPv4/status/1576415168426573825 dark]</code>)</li>
 <li>Pass <code>left</code>, <code>center</code>, or <code>right</code> to align the embed (e.g. <code>[twitter https://twitter.com/MattIPv4/status/1576415168426573825 left]</code>)</li>
 </ul>
+<h3 id="image-compare"><a class="hash-anchor" href="#image-compare" aria-hidden="true"></a>Image compare</h3>
+<p>Compare two images side by side. (url1, url2, height, width)</p>
+<div class="imageCompare" style="--value:50%; height: 500px; width: 500px;">
+    <img class="image-left" src="https://rb.gy/jykhuo" alt="Image left"/>
+    <img class="image-right" src="https://rb.gy/zt5afg" alt="Image right"/>
+    <input type="range" class="control" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--value', `${this.value}%`)" />
+    <svg class="control-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></svg>
+</div>
+<p><em>Both the width and height are optional, with the defaults being 500 for both.</em>\</p>
 <h2 id="step-6-tutorials"><a class="hash-anchor" href="#step-6-tutorials" aria-hidden="true"></a>Step 6 — Tutorials</h2>
 <p>Certain features of our Markdown engine are designed specifically for our tutorial content-types.
 These may not be enabled in all contexts in the DigitalOcean community, but are enabled by default in the do-markdownit plugin.</p>

--- a/index.js
+++ b/index.js
@@ -149,6 +149,10 @@ module.exports = (md, options) => {
         md.use(require('./rules/embeds/twitter'), safeObject(optsObj.twitter));
     }
 
+    if (optsObj.imageCompare !== false) {
+        md.use(require('./rules/embeds/image_compare'), safeObject(optsObj.imageCompare));
+    }
+
     // Register modifiers
 
     if (optsObj.underline !== false) {

--- a/rules/embeds/image_compare.js
+++ b/rules/embeds/image_compare.js
@@ -1,0 +1,113 @@
+/*
+Copyright 2022 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module rules/embeds/image_compare
+ */
+
+/**
+ * Add support for Image Comparison in Markdown, as block syntax.
+ *
+ * The basic syntax is `[image_compare <url1> <url2>]`. E.g., `[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg]`.
+ * Height and width can optionally be set using `[vimeo <url1> <url2> [height] [width]]`. E.g., `[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg 500 560]`.
+ * The default value for height is 500 and for width is 500.
+ *
+ * @example
+ * [image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg]
+ *
+ * <div class="imageCompare" style="--value:50%; height: 500px; width: 500px;">
+ *     <img class="image-left" src="https://rb.gy/jykhuo" alt="Image left"/>
+ *     <img class="image-right" src="https://rb.gy/zt5afg" alt="Image right"/>
+ *     <input type="range" class="control" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--value', `${this.value}%`)" />
+ *     <svg class="control-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></svg>
+ * </div>
+ *
+ * @type {import('markdown-it').PluginSimple}
+ */
+module.exports = md => {
+    /**
+     * Parsing rule for Image compare markup.
+     *
+     * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
+     */
+    const imageCompareRule = (state, startLine, endLine, silent) => {
+        // If silent, don't replace
+        if (silent) return false;
+
+        // Get current string to consider (just current line)
+        const pos = state.bMarks[startLine] + state.tShift[startLine];
+        const max = state.eMarks[startLine];
+        const currentLine = state.src.substring(pos, max);
+
+        // Perform some non-regex checks for speed
+        if (currentLine.length < 19) return false; // [image_compare a b]
+        if (currentLine.slice(0, 15) !== '[image_compare ') return false;
+        if (currentLine[currentLine.length - 1] !== ']') return false;
+
+        // Check for vimeo match
+        const match = currentLine.match(/^\[image_compare (\S+) (\S+)(?: (\d+))?(?: (\d+))?]$/);
+        if (!match) return false;
+
+        // Get the first image
+        const imageLeft = match[1];
+        if (!imageLeft) return false;
+
+        // Get the second image
+        const imageRight = match[2];
+        if (!imageRight) return false;
+
+        // Get the height
+        const height = Number(match[3]) || 500;
+
+        // Get the width
+        const width = Number(match[4]) || 500;
+
+        // Update the pos for the parser
+        state.line = startLine + 1;
+
+        // Add token to state
+        const token = state.push('image_compare', 'image_compare', 0);
+        token.block = true;
+        token.markup = match[0];
+        token.image_compare = { imageLeft, imageRight, height, width };
+
+        // Done
+        return true;
+    };
+
+    md.block.ruler.before('paragraph', 'image_compare', imageCompareRule);
+
+    /**
+     * Rendering rule for image_compare markup.
+     *
+     * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
+     */
+    md.renderer.rules.image_compare = (tokens, index) => {
+        const token = tokens[index];
+
+        // Return the HTML
+        return `<div class="imageCompare" style="--value:50%; height: ${token.image_compare.height}px; width: ${token.image_compare.width}px;">
+    <img class="image-left" src="${token.image_compare.imageLeft}" alt="Image left"/>
+    <img class="image-right" src="${token.image_compare.imageRight}" alt="Image right"/>
+    <input type="range" class="control" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--value', \`\${this.value}%\`)" />
+    <svg class="control-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></svg>
+</div>\n`;
+    };
+};

--- a/rules/embeds/image_compare.test.js
+++ b/rules/embeds/image_compare.test.js
@@ -1,0 +1,69 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const md = require('markdown-it')().use(require('./image_compare'));
+
+it('handles image compare embeds (not inline)', () => {
+    expect(md.render('[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg 400 400]')).toBe(`<div class="imageCompare" style="--value:50%; height: 400px; width: 400px;">
+    <img class="image-left" src="https://rb.gy/jykhuo" alt="Image left"/>
+    <img class="image-right" src="https://rb.gy/zt5afg" alt="Image right"/>
+    <input type="range" class="control" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--value', \`\${this.value}%\`)" />
+    <svg class="control-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></svg>
+</div>
+`);
+});
+
+it('handles image compare embeds with no urls (no embed)', () => {
+    expect(md.render('[image_compare  ]')).toBe(`<p>[image_compare  ]</p>
+`);
+});
+
+it('handles image compare embeds that are unclosed (no embed)', () => {
+    expect(md.render('[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg')).toBe(`<p>[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg</p>
+`);
+});
+
+it('handles image compare embeds without width', () => {
+    expect(md.render('[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg 400]')).toBe(`<div class="imageCompare" style="--value:50%; height: 400px; width: 500px;">
+    <img class="image-left" src="https://rb.gy/jykhuo" alt="Image left"/>
+    <img class="image-right" src="https://rb.gy/zt5afg" alt="Image right"/>
+    <input type="range" class="control" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--value', \`\${this.value}%\`)" />
+    <svg class="control-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></svg>
+</div>
+`);
+});
+
+it('handles image compare embeds without width or height', () => {
+    expect(md.render('[image_compare https://rb.gy/jykhuo https://rb.gy/zt5afg]')).toBe(`<div class="imageCompare" style="--value:50%; height: 500px; width: 500px;">
+    <img class="image-left" src="https://rb.gy/jykhuo" alt="Image left"/>
+    <img class="image-right" src="https://rb.gy/zt5afg" alt="Image right"/>
+    <input type="range" class="control" min="0" max="100" value="50" oninput="this.parentNode.style.setProperty('--value', \`\${this.value}%\`)" />
+    <svg class="control-arrow" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path fill="currentColor" d="M504.3 273.6c4.9-4.5 7.7-10.9 7.7-17.6s-2.8-13-7.7-17.6l-112-104c-7-6.5-17.2-8.2-25.9-4.4s-14.4 12.5-14.4 22l0 56-192 0 0-56c0-9.5-5.7-18.2-14.4-22s-18.9-2.1-25.9 4.4l-112 104C2.8 243 0 249.3 0 256s2.8 13 7.7 17.6l112 104c7 6.5 17.2 8.2 25.9 4.4s14.4-12.5 14.4-22l0-56 192 0 0 56c0 9.5 5.7 18.2 14.4 22s18.9 2.1 25.9-4.4l112-104z"/></svg>
+</div>
+`);
+});
+
+it('handles image compare embeds attempting html injection', () => {
+    expect(md.render('[image_compare <script>alert();</script>]')).toBe(`<p>[image_compare &lt;script&gt;alert();&lt;/script&gt;]</p>
+`);
+});
+
+it('handles vimeo embeds attempting url manipulation', () => {
+    expect(md.render('[vimeo a/../../b 280 560]')).toBe(`<p>[vimeo a/../../b 280 560]</p>
+`);
+});

--- a/styles/_image_compare.scss
+++ b/styles/_image_compare.scss
@@ -1,0 +1,87 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License") !default;
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// imageCompare embeds
+.imageCompare {
+    position: relative;
+}
+
+.image-left,
+.image-right {
+    height: 100%;
+    object-fit: cover;
+    position: absolute;
+    width: 100%;
+}
+.image-left {
+    clip-path: polygon(0% 0%, var(--value) 0%, var(--value) 100%, 0% 100%);
+    margin: 0;
+}
+.image-right {
+    clip-path: polygon(100% 0%, var(--value) 0%, var(--value) 100%, 100% 100%);
+    margin: 0;
+}
+.control-arrow {
+    width: 30px;
+    height: 30px;
+    position: absolute;
+    top: 50%;
+    left: calc(var(--value) - 13px);
+    color: #ffffff;
+    z-index: 90;
+}
+.control {
+    background-color: transparent;
+    box-sizing: border-box;
+    font-family: inherit;
+    height: 100%;
+    outline: none;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 100;
+}
+.control::-moz-range-thumb {
+    background-color: #ffffff;
+    border: none;
+    cursor: ew-resize;
+    height: 100%;
+    width: 2px;
+}
+.control::-webkit-slider-thumb {
+    background-color: #ffffff;
+    border: none;
+    cursor: ew-resize;
+    height: 100%;
+    width: 2px;
+}
+.control::-moz-range-track {
+    background: transparent;
+    background-size: 100%;
+    box-sizing: border-box;
+}
+.control::-webkit-slider-runnable-track {
+    background: transparent;
+    background-size: 100%;
+    box-sizing: border-box;
+    height: 100%;
+}
+.control,
+.control::-webkit-slider-runnable-track,
+.control::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -37,3 +37,4 @@ limitations under the License.
 @import "code_prism";
 @import "code_secondary_label";
 @import "table_wrapper";
+@import "image_compare";


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Image compare

## What issue does this relate to?
N/A

### What should this PR do?
This introduces a new plugin with syntax for embedding side-by-side image comparison in Markdown. The syntax is [image_compare <url1> <url2>], following the same pattern as many of our other embed plugins.

Like other embed plugins, it also supports optional flags after the URL, in this case for setting the height and/or the width (default value for both is 500).

### What are the acceptance criteria?
The new syntax works as expected, allowing the user to embed image comparisons in Markdown content, optionally changing the height and/or width for the images.
