### PR TITLE
Add slideshow plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Add Slideshow embeds
 - (minor) Add Vimeo embeds
 
 

--- a/README.md
+++ b/README.md
@@ -792,20 +792,20 @@ _No options are available for this plugin._
 <details>
 <summary>Add support for Slideshow in Markdown, as block syntax.</summary>
 
-The basic syntax is `[slideshow <url1> <url2>]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]`.
-Height and width can optionally be set using `[slideshow <url1> <url2> [height] [width]]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png 380 560]`.
+The basic syntax is `[slideshow <url1> <url2> <...urls>]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png https://assets.digitalocean.com/banners/nodejs.png]`.
+Height and width can optionally be set using `[slideshow <url1> <url2> <...urls> [height] [width]]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png https://assets.digitalocean.com/banners/nodejs.png 380 560]`.
 The default value for height is 270 and for width is 480.
 
 **Example Markdown input:**
 
-    [slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]
+    [slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png https://assets.digitalocean.com/banners/nodejs.png]
 
 **Example HTML output:**
 
     <div class="slideshow" style="height: 270px; width: 480px;">
         <div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
         <div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
-        <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+        <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /><img src="https://assets.digitalocean.com/banners/nodejs.png" alt="Slide #3" /></div>
     </div>
 
 **Options:**

--- a/README.md
+++ b/README.md
@@ -736,6 +736,35 @@ Set this property to `false` to disable this plugin.
 _No options are available for this plugin._
 </details>
 
+### slideshow
+
+<details>
+<summary>Add support for Slideshow in Markdown, as block syntax.</summary>
+
+The basic syntax is `[slideshow <url1> <url2>]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]`.
+Height and width can optionally be set using `[slideshow <url1> <url2> [height] [width]]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png 380 560]`.
+The default value for height is 270 and for width is 480.
+
+**Example Markdown input:**
+
+    [slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]
+
+**Example HTML output:**
+
+    <div class="slideshow" style="height: 270px; width: 480px;">
+        <div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+        <div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+        <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+    </div>
+
+**Options:**
+
+Pass options for this plugin as the `slideshow` property of the `do-markdownit` plugin options.
+Set this property to `false` to disable this plugin.
+
+_No options are available for this plugin._
+</details>
+
 ### underline
 
 <details>

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -355,9 +355,9 @@ Like a few other embeds, you can also pass optional flags to customize the embed
 
 ### Slideshow
 
-You can also embed Slideshow (url1, url2, ..., url<n>, height, width):
+You can also embed Slideshow (url1, url2, ...urls, height, width):
 
-[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]
+[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png https://assets.digitalocean.com/banners/nodejs.png]
 
 _Both the width and height are optional, with the defaults being 480 and 270 respectively._
 

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -341,6 +341,13 @@ Like a few other embeds, you can also pass optional flags to customize the embed
 - Pass `light` or `dark` to switch the theme of the embed (e.g. `[twitter https://twitter.com/MattIPv4/status/1576415168426573825 dark]`)
 - Pass `left`, `center`, or `right` to align the embed (e.g. `[twitter https://twitter.com/MattIPv4/status/1576415168426573825 left]`)
 
+### Slideshow
+
+You can also embed Slideshow (url1, url2, ..., url<n>, height, width):
+
+[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]
+
+_Both the width and height are optional, with the defaults being 480 and 270 respectively._
 
 ## Step 6 — Tutorials
 

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -343,6 +343,14 @@ For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create 
 <li>Pass <code>light</code> or <code>dark</code> to switch the theme of the embed (e.g. <code>[twitter https://twitter.com/MattIPv4/status/1576415168426573825 dark]</code>)</li>
 <li>Pass <code>left</code>, <code>center</code>, or <code>right</code> to align the embed (e.g. <code>[twitter https://twitter.com/MattIPv4/status/1576415168426573825 left]</code>)</li>
 </ul>
+<h3 id="slideshow"><a class="hash-anchor" href="#slideshow" aria-hidden="true"></a>Slideshow</h3>
+<p>You can also embed Slideshow (url1, url2, …, url&lt;n&gt;, height, width):</p>
+<div class="slideshow" style="height: 270px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+<p><em>Both the width and height are optional, with the defaults being 480 and 270 respectively.</em></p>
 <h2 id="step-6-tutorials"><a class="hash-anchor" href="#step-6-tutorials" aria-hidden="true"></a>Step 6 — Tutorials</h2>
 <p>Certain features of our Markdown engine are designed specifically for our tutorial content-types.
 These may not be enabled in all contexts in the DigitalOcean community, but are enabled by default in the do-markdownit plugin.</p>

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -357,11 +357,11 @@ For example, <code>[codepen MattCowley vwPzeX dark css 384]</code> would create 
 <li>Pass <code>caption</code> to include caption under the post (e.g. <code>[instagram https://www.instagram.com/p/CkQuv3_LRgS caption]</code>)</li>
 </ul>
 <h3 id="slideshow"><a class="hash-anchor" href="#slideshow" aria-hidden="true"></a>Slideshow</h3>
-<p>You can also embed Slideshow (url1, url2, …, url&lt;n&gt;, height, width):</p>
+<p>You can also embed Slideshow (url1, url2, …urls, height, width):</p>
 <div class="slideshow" style="height: 270px; width: 480px;">
 <div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
 <div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
-<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /><img src="https://assets.digitalocean.com/banners/nodejs.png" alt="Slide #3" /></div>
 </div>
 <p><em>Both the width and height are optional, with the defaults being 480 and 270 respectively.</em></p>
 <h2 id="step-6-tutorials"><a class="hash-anchor" href="#step-6-tutorials" aria-hidden="true"></a>Step 6 — Tutorials</h2>

--- a/index.js
+++ b/index.js
@@ -44,6 +44,7 @@ const safeObject = require('./util/safe_object');
  * @property {false} [wistia] Disable Wistia embeds.
  * @property {false} [vimeo] Disable Vimeo embeds.
  * @property {false} [twitter] Disable Twitter embeds.
+ * @property {false} [slidshow] Disable Slideshow embeds.
  * @property {false} [underline] Disable underline syntax.
  * @property {false|import('./modifiers/fence_label').FenceLabelOptions} [fence_label] Disable fence labels, or set options for the feature.
  * @property {false|import('./modifiers/fence_secondary_label').FenceSecondaryLabelOptions} [fence_secondary_label] Disable fence secondary labels, or set options for the feature.
@@ -147,6 +148,10 @@ module.exports = (md, options) => {
 
     if (optsObj.twitter !== false) {
         md.use(require('./rules/embeds/twitter'), safeObject(optsObj.twitter));
+    }
+
+    if (optsObj.slideshow !== false) {
+        md.use(require('./rules/embeds/slideshow'), safeObject(optsObj.slideshow));
     }
 
     // Register modifiers

--- a/rules/embeds/slideshow.js
+++ b/rules/embeds/slideshow.js
@@ -1,9 +1,12 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+
 You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -20,18 +23,18 @@ limitations under the License.
 /**
  * Add support for Slideshow in Markdown, as block syntax.
  *
- * The basic syntax is `[slideshow <url1> <url2>]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]`.
- * Height and width can optionally be set using `[slideshow <url1> <url2> [height] [width]]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png 380 560]`.
+ * The basic syntax is `[slideshow <url1> <url2> <...urls>]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png https://assets.digitalocean.com/banners/nodejs.png]`.
+ * Height and width can optionally be set using `[slideshow <url1> <url2> <...urls> [height] [width]]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png https://assets.digitalocean.com/banners/nodejs.png 380 560]`.
  * The default value for height is 270 and for width is 480.
  *
  * @example
  *
- * [slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]
+ * [slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png https://assets.digitalocean.com/banners/nodejs.png]
  *
  * <div class="slideshow" style="height: 270px; width: 480px;">
  *      <div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
  *      <div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
- *      <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+ *      <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /><img src="https://assets.digitalocean.com/banners/nodejs.png" alt="Slide #3" /></div>
  * </div>
  *
  * @type {import('markdown-it').PluginSimple}

--- a/rules/embeds/slideshow.js
+++ b/rules/embeds/slideshow.js
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 DigitalOcean
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module rules/embeds/slideshow
+ */
+
+/**
+ * Add support for Slideshow in Markdown, as block syntax.
+ *
+ * The basic syntax is `[slideshow <url1> <url2>]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]`.
+ * Height and width can optionally be set using `[slideshow <url1> <url2> [height] [width]]`. E.g., `[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png 380 560]`.
+ * The default value for height is 270 and for width is 480.
+ *
+ * @example
+ *
+ * [slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]
+ *
+ * <div class="slideshow" style="height: 270px; width: 480px;">
+ *      <div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+ *      <div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+ *      <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+ * </div>
+ *
+ * @type {import('markdown-it').PluginSimple}
+ */
+module.exports = md => {
+    /**
+     * Parsing rule for Slideshow markup.
+     *
+     * @type {import('markdown-it/lib/parser_block').RuleBlock}
+     * @private
+     */
+    const slideshowRule = (state, startLine, endLine, silent) => {
+        // If silent, don't replace
+        if (silent) return false;
+
+        // Get current string to consider (just current line)
+        const pos = state.bMarks[startLine] + state.tShift[startLine];
+        const max = state.eMarks[startLine];
+        const currentLine = state.src.substring(pos, max);
+
+        // Perform some non-regex checks for speed
+        if (currentLine.length < 13) return false; // [slideshow a]
+        if (currentLine.slice(0, 11) !== '[slideshow ') return false;
+        if (currentLine[currentLine.length - 1] !== ']') return false;
+
+        // Check for slideshow match
+        const match = currentLine.match(/^\[slideshow((?: \S+)+)?]$/);
+        if (!match) return false;
+
+        // Get the first image
+        const options = match[1];
+        if (!options) return false;
+
+        // Get the integers for dimensions
+        const numbers = options.split(' ').filter(o => o && Number.isInteger(parseInt(o, 10)));
+
+        // Get the height
+        const height = Number(numbers[0]) || 270;
+
+        // Get the width
+        const width = Number(numbers[1]) || 480;
+
+        // Get everything that is not a simple integer
+        const images = options.split(' ').filter(o => o && !Number.isInteger(parseInt(o, 10)));
+        if (!images.length) {
+            return false;
+        }
+
+        // Update the pos for the parser
+        state.line = startLine + 1;
+
+        // Add token to state
+        const token = state.push('slideshow', 'slideshow', 0);
+        token.block = true;
+        token.markup = match[0];
+        token.slideshow = { images, height, width };
+
+        // Done
+        return true;
+    };
+
+    md.block.ruler.before('paragraph', 'slideshow', slideshowRule);
+
+    /**
+     * Rendering rule for slideshow markup.
+     *
+     * @type {import('markdown-it/lib/renderer').RenderRule}
+     * @private
+     */
+    md.renderer.rules.slideshow = (tokens, index) => {
+        const token = tokens[index];
+        const slides = token.slideshow.images.map((image, idx) => `<img src="${md.utils.escapeHtml(image)}" alt="Slide #${idx + 1}" />`);
+        // Return the HTML
+        return `<div class="slideshow" style="height: ${md.utils.escapeHtml(token.slideshow.height)}px; width: ${md.utils.escapeHtml(token.slideshow.width)}px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= ${token.slideshow.width})()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += ${token.slideshow.width})()">&#8250;</div>
+<div class="slides">${slides.join('')}</div>
+</div>\n`;
+    };
+};

--- a/rules/embeds/slideshow.test.js
+++ b/rules/embeds/slideshow.test.js
@@ -1,0 +1,89 @@
+/*
+Copyright 2023 DigitalOcean
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+const md = require('markdown-it')().use(require('./slideshow'));
+
+it('handles slideshow embeds (not inline)', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png 400 400]')).toBe(`<div class="slideshow" style="height: 400px; width: 400px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 400)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 400)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds with no urls (no embed)', () => {
+    expect(md.render('[slideshow  ]')).toBe(`<p>[slideshow  ]</p>
+`);
+});
+
+it('handles slideshow embeds that are unclosed (no embed)', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png')).toBe(`<p>[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png</p>
+`);
+});
+
+it('handles slideshow embeds with one url', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png]')).toBe(`<div class="slideshow" style="height: 270px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds without width or height', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 270px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds without width', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png 400]')).toBe(`<div class="slideshow" style="height: 400px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds attempting html injection', () => {
+    expect(md.render('[slideshow <script>alert();</script>]')).toBe(`<div class="slideshow" style="height: 270px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="&lt;script&gt;alert();&lt;/script&gt;" alt="Slide #1" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds attempting js injection', () => {
+    expect(md.render('[slideshow " onload="alert();]')).toBe(`<div class="slideshow" style="height: 270px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="&quot;" alt="Slide #1" /><img src="onload=&quot;alert();" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds attempting url manipulation', () => {
+    expect(md.render('[slideshow a/../../b a/../../b 280 560]')).toBe(`<div class="slideshow" style="height: 280px; width: 560px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 560)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 560)()">&#8250;</div>
+<div class="slides"><img src="a/../../b" alt="Slide #1" /><img src="a/../../b" alt="Slide #2" /></div>
+</div>
+`);
+});

--- a/rules/embeds/slideshow.test.js
+++ b/rules/embeds/slideshow.test.js
@@ -64,8 +64,26 @@ it('handles slideshow embeds without width', () => {
 `);
 });
 
-it('handles slideshow embeds with height and width in random places', () => {
-    expect(md.render('[slideshow 400 https://assets.digitalocean.com/banners/python.png 500 https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 500px;">
+it('handles slideshow embeds with height between urls', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png 400 https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds with height before urls', () => {
+    expect(md.render('[slideshow 400 https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds with height and width between urls', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png 400 500 https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 500px;">
 <div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 500)()">&#8249;</div>
 <div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 500)()">&#8250;</div>
 <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
@@ -73,10 +91,19 @@ it('handles slideshow embeds with height and width in random places', () => {
 `);
 });
 
-it('handles slideshow embeds with height anywhere in the options', () => {
-    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png 400 https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 480px;">
-<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
-<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+it('handles slideshow embeds with height and width before urls', () => {
+    expect(md.render('[slideshow 400 500 https://assets.digitalocean.com/banners/python.png https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 500px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 500)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 500)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds with height and width in random places', () => {
+    expect(md.render('[slideshow 400 https://assets.digitalocean.com/banners/python.png 500 https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 500px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 500)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 500)()">&#8250;</div>
 <div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
 </div>
 `);

--- a/rules/embeds/slideshow.test.js
+++ b/rules/embeds/slideshow.test.js
@@ -64,6 +64,24 @@ it('handles slideshow embeds without width', () => {
 `);
 });
 
+it('handles slideshow embeds with height and width in random places', () => {
+    expect(md.render('[slideshow 400 https://assets.digitalocean.com/banners/python.png 500 https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 500px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 500)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 500)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
+it('handles slideshow embeds with height anywhere in the options', () => {
+    expect(md.render('[slideshow https://assets.digitalocean.com/banners/python.png 400 https://assets.digitalocean.com/banners/javascript.png]')).toBe(`<div class="slideshow" style="height: 400px; width: 480px;">
+<div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>
+<div class="action right" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft += 480)()">&#8250;</div>
+<div class="slides"><img src="https://assets.digitalocean.com/banners/python.png" alt="Slide #1" /><img src="https://assets.digitalocean.com/banners/javascript.png" alt="Slide #2" /></div>
+</div>
+`);
+});
+
 it('handles slideshow embeds attempting html injection', () => {
     expect(md.render('[slideshow <script>alert();</script>]')).toBe(`<div class="slideshow" style="height: 270px; width: 480px;">
 <div class="action left" onclick="(() => this.parentNode.getElementsByClassName('slides')[0].scrollLeft -= 480)()">&#8249;</div>

--- a/rules/embeds/slideshow.test.js
+++ b/rules/embeds/slideshow.test.js
@@ -1,9 +1,12 @@
 /*
 Copyright 2023 DigitalOcean
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
+
 You may obtain a copy of the License at
     http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/styles/_slideshow.scss
+++ b/styles/_slideshow.scss
@@ -1,22 +1,22 @@
 .slideshow {
     margin: 0 auto;
-    overflow: hidden;
     position: relative;
+    overflow: hidden;
 
     .action {
-        position: absolute;
-        width: 30px;
-        height: 30px;
+        background-color: hsla(0deg, 10%, 70%, 0.2);
+        border: 1px solid #666666;
         border-radius: 50%;
-        border: 1px solid #666;
-        background-color: hsla(0, 10%, 70%, 0.2);
-        top: 50%;
-        z-index: 10;
-        font-size: 32px;
-        text-align: center;
-        color: #666;
-        line-height: 22px;
+        color: #666666;
         cursor: pointer;
+        font-size: 32px;
+        height: 30px;
+        line-height: 22px;
+        position: absolute;
+        text-align: center;
+        top: 50%;
+        width: 30px;
+        z-index: 10;
 
         &.left {
             left: 10px;
@@ -27,43 +27,33 @@
         }
 
         &:hover {
-            background-color: hsla(0, 10%, 70%, 0.1);
-            border: 1px solid #ccc;
-            color: #ccc;
+            background-color: hsla(0deg, 10%, 70%, 0.1);
+            border: 1px solid #cccccc;
+            color: #cccccc;
         }
     }
 
     .slides {
         display: flex;
-
         overflow-x: auto;
         scroll-snap-type: x mandatory;
-
         scroll-behavior: smooth;
         -webkit-overflow-scrolling: touch;
-
-        /*
-        scroll-snap-points-x: repeat(300px);
-        scroll-snap-type: mandatory;
-        */
     }
 
     .slides > img {
-        scroll-snap-align: start;
+        align-items: center;
+        display: flex;
         flex-shrink: 0;
-        width: 100%;
+        font-size: 100px;
         height: 100%;
+        justify-content: center;
         margin-right: 50px;
-        border-radius: 10px;
-        background: #eee;
+        scroll-snap-align: start;
+        position: relative;
         transform-origin: center center;
         transform: scale(1);
         transition: transform 0.5s;
-        position: relative;
-
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        font-size: 100px;
+        width: 100%;
     }
 }

--- a/styles/_slideshow.scss
+++ b/styles/_slideshow.scss
@@ -1,3 +1,19 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 .slideshow {
     margin: 0 auto;
     position: relative;
@@ -39,21 +55,21 @@
         scroll-snap-type: x mandatory;
         scroll-behavior: smooth;
         -webkit-overflow-scrolling: touch;
-    }
 
-    .slides > img {
-        align-items: center;
-        display: flex;
-        flex-shrink: 0;
-        font-size: 100px;
-        height: 100%;
-        justify-content: center;
-        margin-right: 50px;
-        scroll-snap-align: start;
-        position: relative;
-        transform-origin: center center;
-        transform: scale(1);
-        transition: transform 0.5s;
-        width: 100%;
+        > img {
+            align-items: center;
+            display: flex;
+            flex-shrink: 0;
+            font-size: 100px;
+            height: 100%;
+            justify-content: center;
+            margin-right: 50px;
+            scroll-snap-align: start;
+            position: relative;
+            transform-origin: center center;
+            transform: scale(1);
+            transition: transform 0.5s;
+            width: 100%;
+        }
     }
 }

--- a/styles/_slideshow.scss
+++ b/styles/_slideshow.scss
@@ -1,0 +1,69 @@
+.slideshow {
+    margin: 0 auto;
+    overflow: hidden;
+    position: relative;
+
+    .action {
+        position: absolute;
+        width: 30px;
+        height: 30px;
+        border-radius: 50%;
+        border: 1px solid #666;
+        background-color: hsla(0, 10%, 70%, 0.2);
+        top: 50%;
+        z-index: 10;
+        font-size: 32px;
+        text-align: center;
+        color: #666;
+        line-height: 22px;
+        cursor: pointer;
+
+        &.left {
+            left: 10px;
+        }
+
+        &.right {
+            right: 10px;
+        }
+
+        &:hover {
+            background-color: hsla(0, 10%, 70%, 0.1);
+            border: 1px solid #ccc;
+            color: #ccc;
+        }
+    }
+
+    .slides {
+        display: flex;
+
+        overflow-x: auto;
+        scroll-snap-type: x mandatory;
+
+        scroll-behavior: smooth;
+        -webkit-overflow-scrolling: touch;
+
+        /*
+        scroll-snap-points-x: repeat(300px);
+        scroll-snap-type: mandatory;
+        */
+    }
+
+    .slides > img {
+        scroll-snap-align: start;
+        flex-shrink: 0;
+        width: 100%;
+        height: 100%;
+        margin-right: 50px;
+        border-radius: 10px;
+        background: #eee;
+        transform-origin: center center;
+        transform: scale(1);
+        transition: transform 0.5s;
+        position: relative;
+
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        font-size: 100px;
+    }
+}

--- a/styles/index.scss
+++ b/styles/index.scss
@@ -29,6 +29,7 @@ limitations under the License.
 @import "columns";
 @import "details";
 @import "twitter";
+@import "slideshow";
 @import "heading_id";
 @import "highlight";
 @import "callouts";


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Slideshow plugin

## What issue does this relate to?
N/A

### What should this PR do?
This introduces a new plugin with syntax for embedding slideshows in Markdown. The syntax is [slideshow <url1> <url2> ... <url<n>> ], following the same pattern as many of our other embed plugins.

Like other embed plugins, it also supports optional flags after the URLs, in this case for setting the height and/or the width (default value is 270px for height and 480px for width ).

### What are the acceptance criteria?
The new syntax works as expected, allowing the user to embed slideshows in Markdown content, optionally changing the height and/or width for the images.
