### PR TITLE
Replace Slimdom with htmlparser2-related packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Replace Slimdom with htmlparser2-related packages
+
 
 ## v1.6.0 - 03138f3
 

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -129,8 +129,8 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 <span class="token punctuation">}</span>
 </code></pre>
 <p>Examples can have line numbers, and every code block has a ‘Copy’ button to copy just the code:</p>
-<pre class="prefixed line_numbers language-javascript"><code><ol><li data-prefix="1"><span class="token keyword">const</span> test <span class="token operator">=</span> <span class="token string">'hello'</span><span class="token punctuation">;</span>
-</li><li data-prefix="2"><span class="token keyword">const</span> other <span class="token operator">=</span> <span class="token string">'world'</span><span class="token punctuation">;</span>
+<pre class="prefixed line_numbers language-javascript"><code><ol><li data-prefix="1"><span class="token keyword">const</span> test <span class="token operator">=</span> <span class="token string">&apos;hello&apos;</span><span class="token punctuation">;</span>
+</li><li data-prefix="2"><span class="token keyword">const</span> other <span class="token operator">=</span> <span class="token string">&apos;world&apos;</span><span class="token punctuation">;</span>
 </li><li data-prefix="3">console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span>test<span class="token punctuation">,</span> other<span class="token punctuation">)</span><span class="token punctuation">;</span>
 </li></ol>
 </code></pre>
@@ -138,8 +138,8 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 <pre><code><div class="secondary-code-label" title="Output">Output</div>Could not connect to Redis at 127.0.0.1:6379: Connection refused
 </code></pre>
 <p>This is a non-root user command example:</p>
-<pre class="prefixed command language-bash"><code><ol><li data-prefix="$"><span class="token function">sudo</span> <span class="token function">apt-get</span> update
-</li><li data-prefix="$"><span class="token function">sudo</span> <span class="token function">apt-get</span> <span class="token function">install</span> python3
+<pre class="prefixed command language-bash"><code><ol><li data-prefix="&#x24;"><span class="token function">sudo</span> <span class="token function">apt-get</span> update
+</li><li data-prefix="&#x24;"><span class="token function">sudo</span> <span class="token function">apt-get</span> <span class="token function">install</span> python3
 </li></ol>
 </code></pre>
 <p>This is a root command example:</p>
@@ -158,19 +158,19 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 </li></ol>
 </code></pre>
 <p>Indicate where commands are being run with environments:</p>
-<pre class="prefixed command environment-local language-bash"><code><ol><li data-prefix="$"><span class="token function">ssh</span> root@server_ip
+<pre class="prefixed command environment-local language-bash"><code><ol><li data-prefix="&#x24;"><span class="token function">ssh</span> root@server_ip
 </li></ol>
 </code></pre>
-<pre class="prefixed command environment-second language-bash"><code><ol><li data-prefix="$"><span class="token builtin class-name">echo</span> <span class="token string">"Secondary server"</span>
+<pre class="prefixed command environment-second language-bash"><code><ol><li data-prefix="&#x24;"><span class="token builtin class-name">echo</span> <span class="token string">&quot;Secondary server&quot;</span>
 </li></ol>
 </code></pre>
-<pre class="prefixed command environment-third language-bash"><code><ol><li data-prefix="$"><span class="token builtin class-name">echo</span> <span class="token string">"Tertiary server"</span>
+<pre class="prefixed command environment-third language-bash"><code><ol><li data-prefix="&#x24;"><span class="token builtin class-name">echo</span> <span class="token string">&quot;Tertiary server&quot;</span>
 </li></ol>
 </code></pre>
-<pre class="prefixed command environment-fourth language-bash"><code><ol><li data-prefix="$"><span class="token builtin class-name">echo</span> <span class="token string">"Quaternary server"</span>
+<pre class="prefixed command environment-fourth language-bash"><code><ol><li data-prefix="&#x24;"><span class="token builtin class-name">echo</span> <span class="token string">&quot;Quaternary server&quot;</span>
 </li></ol>
 </code></pre>
-<pre class="prefixed command environment-fifth language-bash"><code><ol><li data-prefix="$"><span class="token builtin class-name">echo</span> <span class="token string">"Quinary server"</span>
+<pre class="prefixed command environment-fifth language-bash"><code><ol><li data-prefix="&#x24;"><span class="token builtin class-name">echo</span> <span class="token string">&quot;Quinary server&quot;</span>
 </li></ol>
 </code></pre>
 <p>And all of these can be combined together, with a language for syntax highlighting as well as a line prefix (line numbers, command, custom prefix, etc.), and even an environment and label:</p>
@@ -226,7 +226,7 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 <p>Inside the details block you can use any block or inline syntax.</p>
 <p>You could hide the solution to a problem:</p>
 <pre class="language-javascript"><code><span class="token comment">// Write a message to console</span>
-console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">'Hello, world!'</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">&apos;Hello, world!&apos;</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 </code></pre>
 </details>
 <details open="">

--- a/modifiers/prismjs.test.js
+++ b/modifiers/prismjs.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ it('handles a code fence with a language (adding the class to the pre + highligh
 });
 
 it('handles a code fence with a language alias', () => {
-    expect(md.render('```js\nconsole.log("test");\n```')).toBe(`<pre class="language-javascript"><code class="language-js">console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">"test"</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
+    expect(md.render('```js\nconsole.log("test");\n```')).toBe(`<pre class="language-javascript"><code class="language-js">console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span><span class="token string">&quot;test&quot;</span><span class="token punctuation">)</span><span class="token punctuation">;</span>
 </code></pre>
 `);
 });
@@ -48,6 +48,7 @@ describe('HTML preservation', () => {
     const mdHtml = require('markdown-it')()
         .use(require('../rules/highlight'))
         .use(require('./fence_label'))
+        .use(require('./fence_prefix'))
         .use(require('./prismjs'));
 
     it('handles a token at the start of the code block', () => {
@@ -75,7 +76,7 @@ describe('HTML preservation', () => {
     });
 
     it('handles HTML inside a token in the code block', () => {
-        expect(mdHtml.render('```js\nreturn \'hello <^>world<^>\';\n```')).toBe(`<pre class="language-javascript"><code class="language-js"><span class="token keyword">return</span> <span class="token string">'hello <mark>world</mark>'</span><span class="token punctuation">;</span>
+        expect(mdHtml.render('```js\nreturn \'hello <^>world<^>\';\n```')).toBe(`<pre class="language-javascript"><code class="language-js"><span class="token keyword">return</span> <span class="token string">&apos;hello <mark>world</mark>&apos;</span><span class="token punctuation">;</span>
 </code></pre>
 `);
     });
@@ -103,6 +104,15 @@ describe('HTML preservation', () => {
     it('handles HTML outside the code block', () => {
         expect(mdHtml.render('```typescript\n[label test/hello/world.ts]\nconst test: number = 1;\n```')).toBe(`<div class="code-label" title="test/hello/world.ts">test/hello/world.ts</div>
 <pre class="language-typescript"><code class="language-typescript"><span class="token keyword">const</span> test<span class="token operator">:</span> <span class="token builtin">number</span> <span class="token operator">=</span> <span class="token number">1</span><span class="token punctuation">;</span>
+</code></pre>
+`);
+    });
+
+    it('handles HTML wrapping each line', () => {
+        expect(mdHtml.render('```javascript,line_numbers\nconst test = \'hello\';\nconst other = \'world\';\nconsole.log(test, other);\n```')).toBe(`<pre class="language-javascript"><code class="prefixed line_numbers language-javascript"><ol><li data-prefix="1"><span class="token keyword">const</span> test <span class="token operator">=</span> <span class="token string">&apos;hello&apos;</span><span class="token punctuation">;</span>
+</li><li data-prefix="2"><span class="token keyword">const</span> other <span class="token operator">=</span> <span class="token string">&apos;world&apos;</span><span class="token punctuation">;</span>
+</li><li data-prefix="3">console<span class="token punctuation">.</span><span class="token function">log</span><span class="token punctuation">(</span>test<span class="token punctuation">,</span> other<span class="token punctuation">)</span><span class="token punctuation">;</span>
+</li></ol>
 </code></pre>
 `);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domhandler": "^5.0.3",
+        "domutils": "^3.0.1",
         "htmlparser2": "^8.0.1",
-        "prismjs": "^1.29.0",
-        "slimdom": "^4.1.1"
+        "prismjs": "^1.29.0"
       },
       "devDependencies": {
         "@types/markdown-it": "^12.2.3",
@@ -2873,6 +2875,49 @@
         "url": "https://github.com/sponsors/fb55"
       }
     },
+    "node_modules/css-select/node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/css-select/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/css-tree": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-2.3.1.tgz",
@@ -3111,17 +3156,27 @@
       }
     },
     "node_modules/dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "dependencies": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
       },
       "funding": {
         "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/dom-serializer/node_modules/entities": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+      "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/domelementtype": {
@@ -3136,12 +3191,11 @@
       ]
     },
     "node_modules/domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "dependencies": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       },
       "engines": {
         "node": ">= 4"
@@ -3151,14 +3205,13 @@
       }
     },
     "node_modules/domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "dependencies": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       },
       "funding": {
         "url": "https://github.com/fb55/domutils?sponsor=1"
@@ -4744,46 +4797,6 @@
         "domhandler": "^5.0.2",
         "domutils": "^3.0.1",
         "entities": "^4.3.0"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/dom-serializer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-      "dependencies": {
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.2",
-        "entities": "^4.2.0"
-      },
-      "funding": {
-        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domhandler": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-      "dependencies": {
-        "domelementtype": "^2.3.0"
-      },
-      "engines": {
-        "node": ">= 4"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domhandler?sponsor=1"
-      }
-    },
-    "node_modules/htmlparser2/node_modules/domutils": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-      "dependencies": {
-        "dom-serializer": "^2.0.0",
-        "domelementtype": "^2.3.0",
-        "domhandler": "^5.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
@@ -7723,6 +7736,49 @@
         "strip-ansi": "^6.0.1"
       }
     },
+    "node_modules/renderkid/node_modules/dom-serializer": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+      "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.0",
+        "entities": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/renderkid/node_modules/domhandler": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+      "dev": true,
+      "dependencies": {
+        "domelementtype": "^2.2.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/renderkid/node_modules/domutils": {
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+      "dev": true,
+      "dependencies": {
+        "dom-serializer": "^1.0.1",
+        "domelementtype": "^2.2.0",
+        "domhandler": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
     "node_modules/renderkid/node_modules/htmlparser2": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -8251,11 +8307,6 @@
       "funding": {
         "url": "https://github.com/chalk/slice-ansi?sponsor=1"
       }
-    },
-    "node_modules/slimdom": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/slimdom/-/slimdom-4.1.1.tgz",
-      "integrity": "sha512-6uOFEI++GVgwxEfYMpL96c2/MlTE12saSBTxrN+7II0rkxyaRJS8vXLl9QjjStrHr+zo2PukpesnnXY2D8gBAw=="
     },
     "node_modules/sockjs": {
       "version": "0.3.24",
@@ -11977,6 +12028,39 @@
         "domhandler": "^4.3.1",
         "domutils": "^2.8.0",
         "nth-check": "^2.0.1"
+      },
+      "dependencies": {
+        "dom-serializer": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+          "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domhandler": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        }
       }
     },
     "css-tree": {
@@ -12150,14 +12234,20 @@
       }
     },
     "dom-serializer": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
-      "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dev": true,
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
       "requires": {
-        "domelementtype": "^2.0.1",
-        "domhandler": "^4.2.0",
-        "entities": "^2.0.0"
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-4.4.0.tgz",
+          "integrity": "sha512-oYp7156SP8LkeGD0GF85ad1X9Ai79WtRsZ2gxJqtBuzH+98YUV6jkHEKlZkMbcrjJjIVJNIDP/3WL9wQkoPbWA=="
+        }
       }
     },
     "domelementtype": {
@@ -12166,23 +12256,21 @@
       "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
     },
     "domhandler": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
-      "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
-      "dev": true,
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
       "requires": {
-        "domelementtype": "^2.2.0"
+        "domelementtype": "^2.3.0"
       }
     },
     "domutils": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
-      "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
+      "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
       "requires": {
-        "dom-serializer": "^1.0.1",
-        "domelementtype": "^2.2.0",
-        "domhandler": "^4.2.0"
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.1"
       }
     },
     "dot-case": {
@@ -13381,34 +13469,6 @@
         "entities": "^4.3.0"
       },
       "dependencies": {
-        "dom-serializer": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
-          "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
-          "requires": {
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.2",
-            "entities": "^4.2.0"
-          }
-        },
-        "domhandler": {
-          "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
-          "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
-          "requires": {
-            "domelementtype": "^2.3.0"
-          }
-        },
-        "domutils": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-          "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
-          "requires": {
-            "dom-serializer": "^2.0.0",
-            "domelementtype": "^2.3.0",
-            "domhandler": "^5.0.1"
-          }
-        },
         "entities": {
           "version": "4.3.1",
           "resolved": "https://registry.npmjs.org/entities/-/entities-4.3.1.tgz",
@@ -15569,6 +15629,37 @@
         "strip-ansi": "^6.0.1"
       },
       "dependencies": {
+        "dom-serializer": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.4.1.tgz",
+          "integrity": "sha512-VHwB3KfrcOOkelEG2ZOfxqLZdfkil8PtJi4P8N2MMXucZq2yLp75ClViUlOVwyoHEDjYU433Aq+5zWP61+RGag==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.0",
+            "entities": "^2.0.0"
+          }
+        },
+        "domhandler": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
+          "integrity": "sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==",
+          "dev": true,
+          "requires": {
+            "domelementtype": "^2.2.0"
+          }
+        },
+        "domutils": {
+          "version": "2.8.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
+          "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
+          "dev": true,
+          "requires": {
+            "dom-serializer": "^1.0.1",
+            "domelementtype": "^2.2.0",
+            "domhandler": "^4.2.0"
+          }
+        },
         "htmlparser2": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
@@ -15960,11 +16051,6 @@
         "astral-regex": "^2.0.0",
         "is-fullwidth-code-point": "^3.0.0"
       }
-    },
-    "slimdom": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/slimdom/-/slimdom-4.1.1.tgz",
-      "integrity": "sha512-6uOFEI++GVgwxEfYMpL96c2/MlTE12saSBTxrN+7II0rkxyaRJS8vXLl9QjjStrHr+zo2PukpesnnXY2D8gBAw=="
     },
     "sockjs": {
       "version": "0.3.24",

--- a/package.json
+++ b/package.json
@@ -70,8 +70,10 @@
     "webpack-dev-server": "^4.11.1"
   },
   "dependencies": {
+    "dom-serializer": "^2.0.0",
+    "domhandler": "^5.0.3",
+    "domutils": "^3.0.1",
     "htmlparser2": "^8.0.1",
-    "prismjs": "^1.29.0",
-    "slimdom": "^4.1.1"
+    "prismjs": "^1.29.0"
   }
 }

--- a/util/dom_utils.js
+++ b/util/dom_utils.js
@@ -33,11 +33,12 @@ const domRemoveEmpty = node => {
  * Find the leaf node of a given node.
  *
  * @param {import('domhandler').Node} node Node to find leaf for.
- * @return {import('domhandler').Node}
+ * @returns {import('domhandler').Node}
  * @private
  */
 const domLeaf = node => {
     let workingNode = node;
+    // eslint-disable-next-line no-constant-condition
     while (true) {
         const children = getChildren(workingNode);
         if (children.length === 0) return workingNode;
@@ -50,7 +51,7 @@ const domLeaf = node => {
  *
  * @param {import('domhandler').Node} node Node to check for child.
  * @param {import('domhandler').Node} child Node to check for.
- * @return {boolean}
+ * @returns {boolean}
  * @private
  */
 const domContains = (node, child) => {

--- a/util/dom_utils.js
+++ b/util/dom_utils.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2023 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -16,24 +16,59 @@ limitations under the License.
 
 'use strict';
 
+const { textContent, getChildren, removeElement, append, appendChild, prependChild } = require('domutils');
+
 /**
  * Remove all nodes that have no text content recursively, including the given node.
  *
- * @param {Node} node Node to remove empty nodes from (including self).
+ * @param {import('domhandler').Node} node Node to remove empty nodes from (including self).
  * @private
  */
 const domRemoveEmpty = node => {
-    for (const child of [ ...node.childNodes ]) domRemoveEmpty(child);
-    if (node.textContent === '') node.parentNode.removeChild(node);
+    for (const child of getChildren(node)) domRemoveEmpty(child);
+    if (textContent(node) === '') removeElement(node);
+};
+
+/**
+ * Find the leaf node of a given node.
+ *
+ * @param {import('domhandler').Node} node Node to find leaf for.
+ * @return {import('domhandler').Node}
+ * @private
+ */
+const domLeaf = node => {
+    let workingNode = node;
+    while (true) {
+        const children = getChildren(workingNode);
+        if (children.length === 0) return workingNode;
+        workingNode = children[0];
+    }
+};
+
+/**
+ * Check if a given node contains another node, recursively.
+ *
+ * @param {import('domhandler').Node} node Node to check for child.
+ * @param {import('domhandler').Node} child Node to check for.
+ * @return {boolean}
+ * @private
+ */
+const domContains = (node, child) => {
+    let parent = child.parentNode;
+    while (parent) {
+        if (parent === node) return true;
+        parent = parent.parentNode;
+    }
+    return false;
 };
 
 /**
  * Find the next sibling leaf node after a given node.
  * Explores up the tree as far as the given root to find the next leaf.
  *
- * @param {Node} node Node to find next leaf for.
- * @param {Node} root Node to consider the root of the tree.
- * @returns {?Node}
+ * @param {import('domhandler').Node} node Node to find next leaf for.
+ * @param {import('domhandler').Node} root Node to consider the root of the tree.
+ * @returns {?import('domhandler').Node}
  * @private
  */
 const domNextSiblingLeaf = (node, root) => {
@@ -45,23 +80,19 @@ const domNextSiblingLeaf = (node, root) => {
         if (workingNode === root) return null;
     }
 
-    // Move to that sibling
-    workingNode = workingNode.nextSibling;
-
-    // Ensure we're at the leaf
-    while (workingNode.firstChild) workingNode = workingNode.firstChild;
-    return workingNode;
+    // Move to that sibling, and ensure we're at the leaf
+    return domLeaf(workingNode.nextSibling);
 };
 
 /**
  * Find the correct node for a text offset from an existing node.
  * Will explore sibling leaf nodes up the tree as far as the given root.
  *
- * @param {Node} node Node to start exploring from.
+ * @param {import('domhandler').Node} node Node to start exploring from.
  * @param {number} offset Text offset to find node for.
- * @param {Node} root Node to consider the root of the tree.
+ * @param {import('domhandler').Node} root Node to consider the root of the tree.
  * @param {boolean} [nextOnExact=false] Move to the next node if the offset is exactly the length of the current node.
- * @returns {{node: Node, offset: number}} The node the remaining offset is within.
+ * @returns {{node: import('domhandler').Node, offset: number}} The node the remaining offset is within.
  * @private
  */
 const domOffsetNode = (node, offset, root, nextOnExact = false) => {
@@ -72,24 +103,25 @@ const domOffsetNode = (node, offset, root, nextOnExact = false) => {
     if (offset === 0) return { node, offset: 0 };
 
     // Jump down to the leaf
-    let workingNode = node;
-    while (workingNode.firstChild) workingNode = workingNode.firstChild;
+    let workingNode = domLeaf(node);
+    let workingText = textContent(workingNode);
 
     // While offset is larger than this node, or this isn't a text node, move along
     let workingOffset = offset;
     while (workingNode.nodeType !== 3
-    || workingOffset > workingNode.textContent.length
-    || (nextOnExact && workingOffset === workingNode.textContent.length)) {
+    || workingOffset > workingText.length
+    || (nextOnExact && workingOffset === workingText.length)) {
         // If text node, adjust offset
         if (workingNode.nodeType === 3
-            && (workingOffset > workingNode.textContent.length
-                || (nextOnExact && workingOffset === workingNode.textContent.length))) {
-            workingOffset -= workingNode.textContent.length;
+            && (workingOffset > workingText.length
+                || (nextOnExact && workingOffset === workingText.length))) {
+            workingOffset -= workingText.length;
         }
 
         // Move to the next node
         workingNode = domNextSiblingLeaf(workingNode, root);
         if (workingNode === null) throw new Error('Offset is larger than the document');
+        workingText = textContent(workingNode);
     }
 
     return { node: workingNode, offset: workingOffset };
@@ -98,31 +130,31 @@ const domOffsetNode = (node, offset, root, nextOnExact = false) => {
 /**
  * Split a node at a given offset up to a given root.
  *
- * @param {Node} root Node to consider the root of the tree.
- * @param {Node} node Node to split.
+ * @param {import('domhandler').Node} root Node to consider the root of the tree.
+ * @param {import('domhandler').Node} node Node to split.
  * @param {?number} [offset=null] Optional offset to split at.
  * @param {boolean} [nodeInRight=true] If the node to split on should be in the right tree of the split.
- * @returns {{left: Node[], right: Node[]}}
+ * @returns {{left: import('domhandler').Node[], right: import('domhandler').Node[]}}
  * @private
  */
 const domSplit = (root, node, offset = null, nodeInRight = true) => {
-    if (!root.contains(node)) throw new Error('Node is not a child of root');
+    if (!domContains(root, node)) throw new Error('Node is not a child of root');
 
     // Handle offset in a node
     let workingNode = node;
     if (offset !== null && offset > 0) {
         // If the node should be in the left, and we're at the full length, don't offset
-        if (nodeInRight || offset < workingNode.textContent.length) {
+        if (nodeInRight || offset < textContent(workingNode).length) {
             if (workingNode.nodeType !== 3) throw new Error('Cannot offset on non-text node');
-            if (offset > workingNode.textContent.length) throw new Error('Offset is larger than the document');
+            if (offset > textContent(workingNode).length) throw new Error('Offset is larger than the document');
 
             // Create a new node for us with the offset text
             const newNode = workingNode.cloneNode(false);
-            newNode.textContent = workingNode.textContent.slice(offset);
-            workingNode.parentNode.insertBefore(newNode, workingNode.nextSibling);
+            newNode.data = textContent(workingNode).slice(offset);
+            append(workingNode, newNode);
 
             // Leave the original node with the left text
-            workingNode.textContent = workingNode.textContent.slice(0, offset);
+            workingNode.data = textContent(workingNode).slice(0, offset);
 
             // Work with the new node
             workingNode = newNode;
@@ -138,13 +170,13 @@ const domSplit = (root, node, offset = null, nodeInRight = true) => {
         if (bound.nextSibling || nodeInRight) {
             // Move everything after the bound in the parent into a new sub-branch
             const right = parent.cloneNode(false);
-            while (bound.nextSibling) right.appendChild(bound.nextSibling);
+            while (bound.nextSibling) appendChild(right, bound.nextSibling);
 
             // Add the new sub-branch after the bound's parent
-            parent.parentNode.insertBefore(right, parent.nextSibling);
+            append(parent, right);
 
             // Handle having the node itself in the right branch
-            if (nodeInRight) right.insertBefore(bound, right.firstChild);
+            if (nodeInRight) prependChild(right, bound);
         }
 
         // Move the bound up
@@ -152,7 +184,7 @@ const domSplit = (root, node, offset = null, nodeInRight = true) => {
     }
 
     // Get the left and right result in the DOM
-    return [ ...root.childNodes ].reduce((obj, child) => {
+    return getChildren(root).reduce((obj, child) => {
         // Node in left, or node in right and in non-root parent
         if (child === bound.nextSibling) obj.right.push(child);
 
@@ -171,15 +203,15 @@ const domSplit = (root, node, offset = null, nodeInRight = true) => {
 /**
  * Find a common ancestor of two nodes.
  *
- * @param {Node} node1 First node to consider.
- * @param {Node} node2 Second node to consider.
- * @returns {?Node}
+ * @param {import('domhandler').Node} node1 First node to consider.
+ * @param {import('domhandler').Node} node2 Second node to consider.
+ * @returns {?import('domhandler').Node}
  * @private
  */
 const domCommonAncestor = (node1, node2) => {
     let parent = node1.parentNode;
     while (parent) {
-        if (parent.contains(node2)) return parent;
+        if (domContains(parent, node2)) return parent;
         parent = parent.parentNode;
     }
     return null;
@@ -188,14 +220,14 @@ const domCommonAncestor = (node1, node2) => {
 /**
  * Check if all direct next siblings of a node have no text content.
  *
- * @param {Node} node Node to consider.
+ * @param {import('domhandler').Node} node Node to consider.
  * @returns {boolean}
  * @private
  */
 const domNextSiblingsEmpty = node => {
     let workingNode = node;
     while (workingNode.nextSibling) {
-        if (workingNode.nextSibling.textContent !== '') return false;
+        if (textContent(workingNode.nextSibling) !== '') return false;
         workingNode = workingNode.nextSibling;
     }
     return true;
@@ -204,14 +236,14 @@ const domNextSiblingsEmpty = node => {
 /**
  * Check if all direct previous siblings of a node have no text content.
  *
- * @param {Node} node Node to consider.
+ * @param {import('domhandler').Node} node Node to consider.
  * @returns {boolean}
  * @private
  */
 const domPreviousSiblingsEmpty = node => {
     let workingNode = node;
     while (workingNode.previousSibling) {
-        if (workingNode.previousSibling.textContent !== '') return false;
+        if (textContent(workingNode.previousSibling) !== '') return false;
         workingNode = workingNode.previousSibling;
     }
     return true;

--- a/util/dom_utils.js
+++ b/util/dom_utils.js
@@ -25,7 +25,7 @@ const { textContent, getChildren, removeElement, append, appendChild, prependChi
  * @private
  */
 const domRemoveEmpty = node => {
-    for (const child of getChildren(node)) domRemoveEmpty(child);
+    for (const child of [ ...getChildren(node) ]) domRemoveEmpty(child);
     if (textContent(node) === '') removeElement(node);
 };
 


### PR DESCRIPTION
## Type of Change

- **PrismJS Integration:** Keep HTML plugin

## What issue does this relate to?

N/A

### What should this PR do?

Update the internal implementation of the keep HTML plugin for PrismJS, replacing the Slimdom dependency with lighter-weight packages from the htmlparser2 ecosystem (which we already used).

This should not impact end users of the package or plugin, beyond changing the internal dependencies to hopefully reduce generated bundle sizes when used on the web.

One minor side-effect of changing this implementation is that more HTML entities are being rewritten as their escaped versions in the output HTML -- this is completely backwards compatible and is just a different way of representing the same data.

This is being treated as a patch change, as it does not introduce any new functionality to the plugin itself, and is backwards compatible.

### What are the acceptance criteria?

slimdom is removed from the package dependencies, keep HTML plugin continues to function as it does before, and all tests pass.