### PR TITLE
Fix README heading ordering, add missing heading_id opts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
-- (docs) Fix README heading ordering
+- (docs) Fix README heading ordering, add missing heading_id opts
 - (minor) Hash link position, heading link + clipboard settings
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (docs) Fix README heading ordering
 - (minor) Hash link position, heading link + clipboard settings
 
 

--- a/README.md
+++ b/README.md
@@ -1098,6 +1098,9 @@ Set this property to `false` to disable this plugin.
 - `hashLink` Set this property to `false` to disable this feature.
     - `maxLevel` (`number`, optional, defaults to `3`): Max heading level to generate hash links for.
     - `class` (`string`, optional, defaults to `hash-anchor`): Class name to use on the anchor tag.
+    - `position` (`'before'|'after'`, optional, defaults to `before`): Position of the anchor tag relative to the heading.
+    - `linkHeading` (`boolean`, optional, defaults to `true`): Whether to link the heading text to the hash link.
+    - `clipboard` (`boolean`, optional, defaults to `true`): Whether to write the hash link to the clipboard on click.
 </details>
 
 ### image_settings

--- a/README.md
+++ b/README.md
@@ -1161,6 +1161,22 @@ Set this property to `false` to disable this plugin.
 - `delimiter` (`string`, optional, defaults to `','`): String to split fence information on.
 </details>
 
+### limit_tokens
+
+<details>
+<summary>Filters and transforms tokens in the token stream.</summary>
+
+**Options:**
+
+Pass options for this plugin as the `limit_tokens` property of the `do-markdownit` plugin options.
+This plugin is disabled by default, pass an object to enable it.
+
+- `allowedTokens` (`string[]`): A list of Markdown tokens that should render
+- `transformTokens` (`Object<string, function(Token): Token>`): An object where the keys are Markdown tokens that should be transformed.
+  The transformation is done based on the value which is a function that expects a [Markdown token](https://markdown-it.github.io/markdown-it/#Token) as a param
+  and returns the transformed token.
+</details>
+
 
 ## PrismJS
 
@@ -1196,22 +1212,6 @@ require('@digitalocean/do-markdownit/util/prism_keep_html')(Prism);
 
 Prism.highlight('console.log("<mark>Hello, world!</mark>");', Prism.languages.javascript, 'javascript');
 ```
-
-## limit_tokens
-
-<details>
-<summary>Filters and transforms tokens in the token stream.</summary>
-
-**Options:**
-
-Pass options for this plugin as the `limit_tokens` property of the `do-markdownit` plugin options.
-Set this property to `false` to disable this plugin.
-
-- `allowedTokens` (`string[]`): A list of Markdown tokens that should render
-- `transformTokens` (`Object<string, function(Token): Token>`): An object where the keys are Markdown tokens that should be transformed.
-  The transformation is done based on the value which is a function that expects a [Markdown token](https://markdown-it.github.io/markdown-it/#Token) as a param
-and returns the transformed token.
-</details>
 
 
 ## Styles


### PR DESCRIPTION
## Type of Change

- **Something else:** Docs

## What issue does this relate to?

N/A

### What should this PR do?

Fixes the ordering/levels of the headings in the README so that the limit_tokens plugin information is a sub-heading of the plugins, rather than being an isolated top-level heading further down the document.

Fixes the listed options for the heading_id plugin, as I forgot in #64 that the nested options for hash links are also included in the README.

### What are the acceptance criteria?

limit_tokens heading is correctly nested under the plugins list in the README.

heading_id hash link options are correctly listed in the README.