### PR TITLE
Isolate Prism webpack logic in own file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Isolate Prism webpack logic in own file
 - (minor) Add util to restrict Prism bundle in Webpack
 
 

--- a/README.md
+++ b/README.md
@@ -1210,11 +1210,11 @@ are included. You can do this by restricting what files from
 `@digitalocean/do-markdownit/vendor/prismjs/components` are included in the bundle --
 `prism-core.js` is the only "required" file, all others are language definitions.
 
-We expose two utilities in the `util/prism_util.js` file to help with this. First is the
-`getDependencies` method which takes a PrismJS language and will return all the language
-dependencies that also need to be loaded for it. For Webpack users specifically, we also expose a
-`restrictWebpack` method that takes an array of PrismJS languages to include and returns a Webpack
-plugin you can include to restrict the paths included in the bundle.
+We expose two utilities to help with this. First is the `getDependencies` method in
+`util/prism_util.js` which takes a PrismJS language and will return all the language dependencies
+that also need to be loaded for it. For Webpack users specifically, we also expose a
+method in `util/prism_webpack.js` that takes an array of PrismJS languages to include and
+returns a Webpack plugin you can include to restrict the paths included in the bundle.
 
 ```js
 const { getDependencies } = require('@digitalocean/do-markdownit/util/prism_util');
@@ -1224,7 +1224,7 @@ console.log(getDependencies('javascript', false)); // [ 'clike', 'markup' ]
 ```
 
 ```js
-const { restrictWebpack } = require('@digitalocean/do-markdownit/util/prism_util');
+const restrictWebpack = require('@digitalocean/do-markdownit/util/prism_webpack');
 
 module.exports = {
   // ...

--- a/modifiers/image_settings.js
+++ b/modifiers/image_settings.js
@@ -21,7 +21,7 @@ limitations under the License.
  */
 
 const safeObject = require('../util/safe_object');
-const regexEscape = require('../util/regex_escape');
+const { regexEscape } = require('../util/helpers');
 
 /**
  * @typedef {Object} ImageSettingsOptions

--- a/util/helpers.js
+++ b/util/helpers.js
@@ -17,9 +17,28 @@ limitations under the License.
 'use strict';
 
 /**
+ * Deduplicate an array.
+ *
+ * @param {any[]} arr Array to deduplicate.
+ * @returns {any[]}
+ * @private
+ */
+module.exports.dedupeArray = arr => Array.from(new Set(arr));
+
+/**
+ * Ensure a value is an array, wrapping it if it is not.
+ *
+ * @param {any|any[]} val Value to ensure is an array.
+ * @returns {any[]}
+ * @private
+ */
+module.exports.alwaysArray = val => (Array.isArray(val) ? val : [ val ]);
+
+/**
  * Escape a string for use in a RegExp.
  *
  * @param {string} string String to escape.
  * @returns {string}
+ * @private
  */
-module.exports = string => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+module.exports.regexEscape = string => string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string

--- a/util/prism_webpack.js
+++ b/util/prism_webpack.js
@@ -1,0 +1,45 @@
+/*
+Copyright 2023 DigitalOcean
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+'use strict';
+
+/**
+ * @module util/prism_webpack
+ */
+
+// This isn't listed as a dependency, as only existing Webpack users will use this
+// eslint-disable-next-line import/no-extraneous-dependencies
+const { ContextReplacementPlugin } = require('webpack');
+
+const { dedupeArray, regexEscape } = require('./helpers');
+const { getDependencies } = require('./prism_util');
+
+/**
+ * Plugin to restrict the languages that are bundled for Prism.
+ *
+ * Automatically resolves and includes all dependencies for the given languages.
+ * This plugin requires that Webpack is installed as a dependency with `ContextReplacementPlugin` available.
+ *
+ * @param {string[]} langs Prism languages to restrict to.
+ * @returns {import('webpack').Plugin}
+ */
+module.exports = langs => {
+    const withDependencies = dedupeArray(langs.flatMap(lang => [ lang, ...getDependencies(lang) ]));
+    return new ContextReplacementPlugin(
+        /@digitalocean[/\\]do-markdownit[/\\]vendor[/\\]prismjs[/\\]components$/,
+        new RegExp(`prism-(${[ 'core', ...withDependencies.map(dep => regexEscape(dep)) ].join('|')})(\\.js)?$`),
+    );
+};


### PR DESCRIPTION
## Type of Change

- **PrismJS Integration:** Webpack

## What issue does this relate to?

cc #69 

### What should this PR do?

Isolates the logic introduced in #69 to handle the case where a bundle is unable to tree-shake dead code paths, and so attempts to bundle Webpack itself.

### What are the acceptance criteria?

Webpack-related logic for Prism is in an isolated file not imported by plugins.