### PR TITLE
Manually track loaded Prism components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
 
+- (patch) Manually track loaded Prism components
+
 # v1.8.0 - aaf8532
 
 - (patch) Dependency updates

--- a/modifiers/prismjs.js
+++ b/modifiers/prismjs.js
@@ -33,18 +33,26 @@ const { languages, languageAliases, getDependencies } = require('../util/prism_u
  */
 
 /**
- * Helper to load in a language if not yet loaded.
+ * Track which Prism components have been loaded.
  *
- * @param {string} language Prism language name to be loaded.
+ * @type {Set<string>}
+ */
+const loaded = new Set();
+
+/**
+ * Helper to load in a Prism component if not yet loaded.
+ *
+ * @param {string} component Prism component name to be loaded.
  * @private
  */
-const loadLanguage = language => {
-    if (language in Prism.languages) return;
+const loadComponent = component => {
+    if (loaded.has(component)) return;
     try {
         // eslint-disable-next-line import/no-dynamic-require
-        require(`../vendor/prismjs/components/prism-${language}`)(Prism);
+        require(`../vendor/prismjs/components/prism-${component}`)(Prism);
+        loaded.add(component);
     } catch (err) {
-        console.error('Failed to load Prism language', language, err);
+        console.error('Failed to load Prism component', component, err);
     }
 };
 
@@ -163,8 +171,8 @@ module.exports = (md, options) => {
             const { before, inside, after } = extractCodeBlock(rendered, language);
 
             // Load requirements for language
-            getDependencies(language.clean).forEach(loadLanguage);
-            loadLanguage(language.clean);
+            getDependencies(language.clean).forEach(loadComponent);
+            loadComponent(language.clean);
 
             // If we failed to load the language (it's a dynamic require), return original
             if (!(language.clean in Prism.languages)) return rendered;

--- a/modifiers/prismjs.test.js
+++ b/modifiers/prismjs.test.js
@@ -32,6 +32,14 @@ it('handles a code fence with a language alias', () => {
 `);
 });
 
+it('does not repeatedly load a modifier component', () => {
+    const error = jest.spyOn(global.console, 'error');
+    md.render('```ts\nconsole.log("test");\n```\n\n```ts\nconsole.log("test");\n```');
+    expect(error).not.toHaveBeenCalledWith(expect.stringContaining('Failed to load Prism component'), 'js-templates', expect.anything());
+    error.mockReset();
+    error.mockRestore();
+});
+
 it('does not pollute global scope', () => {
     global.window = {}; /* global window */
     expect(window).not.toBeUndefined();


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Prism

## What issue does this relate to?

cc #69 

### What should this PR do?

Manually track what Prism components we've loaded, so that we don't repeatedly load components that don't directly load a new language (e.g. modifiers like `js-templates` that modifies `javascript`).

### What are the acceptance criteria?

Modifier components aren't repeatedly loaded when a language that loads one is used in multiple code blocks.

For example, using typescript loads jsx which loads js-templates:

     ```ts
     console.log('test')
     ```

     ```ts
     console.log('test')
     ```
