### PR TITLE
Allow logging for Prism to be toggled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
 
+- (minor) Allow logging for Prism to be toggled
 - (patch) Manually track loaded Prism components
 
 # v1.8.0 - aaf8532

--- a/README.md
+++ b/README.md
@@ -1162,6 +1162,7 @@ Pass options for this plugin as the `prismjs` property of the `do-markdownit` pl
 Set this property to `false` to disable this plugin.
 
 - `delimiter` (`string`, optional, defaults to `','`): String to split fence information on.
+- `logging` (`boolean`, optional, defaults to `false`): Whether to log errors to the console.
 </details>
 
 ### limit_tokens


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Prism

## What issue does this relate to?

N/A

### What should this PR do?

Between the potential for component loading errors logging with the introduction of #69, and the potential for logging errors from bad Prism renders (keep HTML issues normally), logs can get quite noisy when rendering a lot of Markdown.

This PR adds a new option to the Prism plugin to toggle logging for errors, with the default being off. This is a change in the default behaviour, but one I feel still falls under the umbrella of a minor change as the actual output and functionality of the plugin is unchanged.

### What are the acceptance criteria?

When logging is enabled, any render errors will produce an error in console. When logging is disabled, any render errors will be suppressed.