### PR TITLE
Generate TypeScript definitions for package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,18 @@
-.DS_Store
+# Exclude IDEs
 .idea/
-node_modules/
+.vscode/
+
+# Exclude the vendored PrismJS files
 vendor/prismjs/
+
+# Exclude macOS metadata
+.DS_Store
+
+# Exclude Node.js dependencies
+node_modules/
+
+# Exclude generated files
 jsdoc/
+types/
 coverage/
 dev/dist/

--- a/.npmignore
+++ b/.npmignore
@@ -8,8 +8,9 @@ jest.config.js
 # Exclude all development files
 dev/
 
-# Exclude the vendored PrismJS files
+# Exclude the vendored PrismJS files (and types)
 vendor/prismjs/
+types/vendor/prismjs/
 
 # Exclude generated files
 jsdoc/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ plugin will be shipped as minor releases, in that they are adding new functional
 New features will be enabled by default, and may change how your input Markdown is parsed. Any
 breaking changes to the options supported by the plugin will be shipped as a breaking change.
 
+
 ## Unreleased changes
 
 <!--
@@ -17,14 +18,17 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (minor) Generate TypeScript definitions for package
+- (patch) Dependency updates
 
-# v1.9.0 - 5515d0c
+
+## v1.9.0 - 5515d0c
 
 - (minor) Allow logging for Prism to be toggled
 - (patch) Manually track loaded Prism components
 
 
-# v1.8.0 - aaf8532
+## v1.8.0 - aaf8532
 
 - (patch) Dependency updates
 - (patch) Isolate Prism webpack logic in own file

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@types/markdown-it": "^12.2.3",
+        "@types/node": "18.14.2",
         "css-loader": "^6.7.3",
         "eslint": "^8.40.0",
         "eslint-config-airbnb-base": "^15.0.0",
@@ -33,6 +34,7 @@
         "style-loader": "^3.3.2",
         "stylelint": "^15.6.1",
         "stylelint-config-standard-scss": "^9.0.0",
+        "typescript": "^5.1.6",
         "webpack": "^5.82.0",
         "webpack-cli": "^5.1.1",
         "webpack-dev-server": "^4.15.0"
@@ -1548,9 +1550,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "18.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -9197,6 +9199,19 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
     "node_modules/uc.micro": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
@@ -11105,9 +11120,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "17.0.21",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-17.0.21.tgz",
-      "integrity": "sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==",
+      "version": "18.14.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.14.2.tgz",
+      "integrity": "sha512-1uEQxww3DaghA0RxqHx0O0ppVlo43pJhepY51OxuQIKHpjbnYLA7vcdwioNPzIqmC2u3I/dmylcqjlh0e7AyUA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -16777,6 +16792,12 @@
         "for-each": "^0.3.3",
         "is-typed-array": "^1.1.9"
       }
+    },
+    "typescript": {
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.6.tgz",
+      "integrity": "sha512-zaWCozRZ6DLEWAWFrVDz1H6FVXzUSfTy5FUMWsQlU8Ym5JP9eO4xkTIROFCQvhQf61z6O/G6ugw3SgAnvvm+HA==",
+      "dev": true
     },
     "uc.micro": {
       "version": "1.0.6",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "prism"
   ],
   "main": "index.js",
+  "types": "types/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/digitalocean/do-markdownit.git"
@@ -39,8 +40,10 @@
     "lint:scss": "stylelint \"@(styles|dev)/**/*.scss\"",
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "jsdoc": "jsdoc -c .jsdoc.json",
+    "types": "tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir types --lib dom --lib webworker",
     "test": "jest",
     "postinstall": "node script/prism.js",
+    "prepublishOnly": "npm run types",
     "dev": "webpack serve --config dev/webpack.config.js"
   },
   "author": "DigitalOcean",
@@ -50,6 +53,7 @@
   },
   "devDependencies": {
     "@types/markdown-it": "^12.2.3",
+    "@types/node": "18.14.2",
     "css-loader": "^6.7.3",
     "eslint": "^8.40.0",
     "eslint-config-airbnb-base": "^15.0.0",
@@ -65,6 +69,7 @@
     "style-loader": "^3.3.2",
     "stylelint": "^15.6.1",
     "stylelint-config-standard-scss": "^9.0.0",
+    "typescript": "^5.1.6",
     "webpack": "^5.82.0",
     "webpack-cli": "^5.1.1",
     "webpack-dev-server": "^4.15.0"


### PR DESCRIPTION
## Type of Change

- **Build Scripts:** Typings

## What issue does this relate to?

N/A

### What should this PR do?

Introduces TypeScript as a dev dependency, so that prior to publishing a new release we can generate typings from the JSDoc comments automatically.

This also introduced a changelog entry for #77 + #78, and fixes the changelog headings that I did incorrectly in #73 + #76.

### What are the acceptance criteria?

Running `npm publish --dry-run` locally results in the `types` directory being created, and the files within `types` being listed in the NPM output, excluding the files in `types/vendor`.