### PR TITLE
Restrict pattern for space-separated arguments in glob embed regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Fix ReDoS in glob embed rule regex
 - (patch) Dependency updates
 - (patch) Mark markdown-it as a peer dependency
 

--- a/rules/embeds/glob.js
+++ b/rules/embeds/glob.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ module.exports = md => {
         if (closingMark === -1) return false;
 
         // Check for glob match
-        const match = currentLines.slice(0, closingMark + 3).match(/^\[glob (.+?(?:(?: .+?)+|(?:\n.+?)+))\](?:$|\n)/);
+        const match = currentLines.slice(0, closingMark + 3).match(/^\[glob (.+?(?:(?: [^ \n]+?)+|(?:\n.+?)+))\](?:$|\n)/);
         if (!match) return false;
 
         // Get the full strings

--- a/rules/embeds/glob.test.js
+++ b/rules/embeds/glob.test.js
@@ -1,5 +1,5 @@
 /*
-Copyright 2022 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -62,6 +62,16 @@ it('handles glob embeds with linebreaks and spaces in glob', () => {
     expect(md.render('[glob * test.js\n/a\n/b]')).toBe(`<div data-glob-tool-embed data-glob-string="* test.js" data-glob-test-0="/a" data-glob-test-1="/b">
     <a href="https://www.digitalocean.com/community/tools/glob?glob=*+test.js&tests=%2Fa&tests=%2Fb" target="_blank">
         Explore <code>* test.js</code> as a glob string in our glob testing tool
+    </a>
+</div>
+<script async defer src="https://do-community.github.io/glob-tool-embed/bundle.js" type="text/javascript" onload="window.GlobToolEmbeds()"></script>
+`);
+});
+
+it('handles glob embeds with many spaces in glob and a linebreak (ReDos)', () => {
+    expect(md.render(`[glob ${Array.from('a'.repeat(50)).join(' ')}\nb\nc]`)).toBe(`<div data-glob-tool-embed data-glob-string="${Array.from('a'.repeat(50)).join(' ')}" data-glob-test-0="b" data-glob-test-1="c">
+    <a href="https://www.digitalocean.com/community/tools/glob?glob=${Array.from('a'.repeat(50)).join('+')}&tests=b&tests=c" target="_blank">
+        Explore <code>${Array.from('a'.repeat(50)).join(' ')}</code> as a glob string in our glob testing tool
     </a>
 </div>
 <script async defer src="https://do-community.github.io/glob-tool-embed/bundle.js" type="text/javascript" onload="window.GlobToolEmbeds()"></script>


### PR DESCRIPTION
## Type of Change

- **Markdown-It Plugins:** Glob embed

## What issue does this relate to?

N/A

### What should this PR do?

The previous implementation of the regex pattern used for the glob embed could result in too much recursion when evaluating a string that had a large number of spaces in the glob, followed by a test on a new line.

This PR restricts the regex pattern being used, so instead of looking for a space followed by _any_ character, we're now looking for a space followed by _any non-space_ character, avoiding the excessive recursion. A test has also been added to confirm that this regex no longer has this ReDoS issue.

### What are the acceptance criteria?

All tests continue to pass, including the new one that would previously reproduce the ReDoS.