### PR TITLE
Update PUBLISH + CHANGELOG instructions for new versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,15 +10,19 @@ breaking changes to the options supported by the plugin will be shipped as a bre
 
 <!--
 All changes being submitted through PRs should be added to this section.
-Please add a new list item to the top of this section with a summary of the change.
-Each list item should be prefixed with `(patch)` or `(minor)` or `(major)`.
 
+Please add a new list item below this comment with a summary of the change,
+leaving two line-breaks between the final item and the next heading.
+
+Each list item should be prefixed with `(patch)`, `(minor)`, or `(major)`.
 Any non-code changes should be prefixed with `(docs)`.
 
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (docs) Update PUBLISH + CHANGELOG instructions for new versions
 - (patch) Align code-block line numbers to the right
+
 
 ## v1.12.2 - 081867e
 

--- a/PUBLISH.md
+++ b/PUBLISH.md
@@ -5,19 +5,19 @@
 Before beginning a release, ensure that all changes intended for the release are in master, and
 that all tests are passing.
 
-Determine the version number of the release based on the current version number, and the unreleased
-changes listed in [`CHANGELOG.md`](CHANGELOG.md).
+Determine the greatest change (major > minor > patch) made since the last release by reviewing the
+unreleased changes listed in [`CHANGELOG.md`](CHANGELOG.md).
 
-Create a new branch for the release, named `release-v<version>`.
+Update the version in [`package.json`](package.json) and [`package-lock.json`](package-lock.json) by
+running `npm version --no-git-tag-version <patch/minor/major>`.
+
+Create a new branch for the release, using the version from the command, named `release-v<version>`.
 
 Create a new heading in the [`CHANGELOG.md`](CHANGELOG.md) for the release, immediately following
 the unreleased changes section. The heading should follow the format `## v<version> - <hash>`. The
 hash used here should be the final (short) hash in master before the release.
 
 Move all items in the unreleased changes section to be under the new release heading.
-
-Update the version in [`package.json`](package.json) to the new version number, and run
-`npm i --package-lock-only` to update it in [`package-lock.json`](package-lock.json).
 
 Commit the changes, using a message in the format `Release v<version>`, then create a PR to master
 with the release branch using the same message as the title.


### PR DESCRIPTION
## Type of Change

- **Something else:** Docs

## What issue does this relate to?

N/A

### What should this PR do?

As I was prepping the 1.12.3 release, I noticed that the documentation around creating a release was outdated, so this updates it to have more accurate instructions.

### What are the acceptance criteria?

Docs make sense.