### PR TITLE
Fix inline code styling when in a link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Fix inline code styling when in a link
+
 
 ## v1.12.4 - 12a3af3
 

--- a/fixtures/full-input.md
+++ b/fixtures/full-input.md
@@ -64,7 +64,7 @@ Rich transformations are also applied:
 
 ## Step 2 — Code
 
-This is `inline code`. This is a <^>variable<^>. This is an `in-line code <^>variable<^>`.
+This is `inline code`. This is a <^>variable<^>. This is an `in-line code <^>variable<^>`. You can also have [`code` in links](https://www.digitalocean.com).
 
 Here's a configuration file with a label:
 

--- a/fixtures/full-output.html
+++ b/fixtures/full-output.html
@@ -120,7 +120,7 @@ Please refer to our style and formatting guidelines for more detailed explanatio
 </tbody>
 </table>
 </div><h2 id="step-2-code"><a class="hash-anchor" href="#step-2-code" aria-hidden="true" onclick="navigator.clipboard.writeText(this.href);"></a><a href="#step-2-code" onclick="navigator.clipboard.writeText(this.href);">Step 2 — Code</a></h2>
-<p>This is <code>inline code</code>. This is a <mark>variable</mark>. This is an <code>in-line code <mark>variable</mark></code>.</p>
+<p>This is <code>inline code</code>. This is a <mark>variable</mark>. This is an <code>in-line code <mark>variable</mark></code>. You can also have <a href="https://www.digitalocean.com"><code>code</code> in links</a>.</p>
 <p>Here’s a configuration file with a label:</p>
 <div class="code-label" title="/etc/nginx/sites-available/default">/etc/nginx/sites-available/default</div>
 <pre class="language-nginx"><code><span class="token directive"><span class="token keyword">server</span></span> <span class="token punctuation">{</span>

--- a/styles/_code.scss
+++ b/styles/_code.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License") !default;
 you may not use this file except in compliance with the License.
@@ -20,32 +20,46 @@ limitations under the License.
 // Inline code
 pre,
 code {
-    background-color: $gray8;
-    border-radius: 8px;
     color: $gray3;
-    font-size: 14px;
-    line-height: 22px;
-    padding: 3px;
+    font-size: 0.875em;
+    padding: 0 0.2em;
+    position: relative;
+
+    &::before {
+        background-color: $gray8;
+        border-radius: 0.5em;
+        content: "";
+        display: block;
+        inset: -0.2em 0;
+        position: absolute;
+        z-index: -1;
+    }
 }
 
 // Code blocks
 pre {
     @include code-block-theme($code-background-dark, $code-text-dark);
 
-    border-radius: 16px;
-    box-shadow: inset 0 0 0 2px $card-stroke;
+    border-radius: 1em;
+    box-shadow: inset 0 0 0 0.125em $card-stroke;
     display: block;
     margin: 1em 0;
     overflow: auto;
     overflow-wrap: normal;
-    padding: 24px;
+    padding: 1.5em;
     white-space: normal;
     word-wrap: normal;
 
+    &,
     code {
-        background: 0;
-        border-radius: 0;
+        &::before {
+            display: none;
+        }
+    }
+
+    code {
         color: inherit;
+        font-size: 1em;
         padding: 0;
         white-space: pre;
     }

--- a/styles/_code_prism.scss
+++ b/styles/_code_prism.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License") !default;
 you may not use this file except in compliance with the License.
@@ -86,8 +86,8 @@ pre {
 
     > .toolbar {
         position: absolute;
-        right: 24px;
-        top: 24px;
+        right: calc(1.5em - 0.5em);
+        top: calc(1.5em - 0.375em);
 
         > .toolbar-item {
             display: inline-block;
@@ -107,11 +107,12 @@ pre {
             > a,
             > button {
                 background: $neutral3;
-                border-radius: 10px;
+                border-radius: 0.625em;
                 color: $white;
                 cursor: pointer;
-                padding: 6px 8px;
-                transition: color 0.25s, background 0.25s; 
+                line-height: 1;
+                padding: 0.375em 0.5em;
+                transition: color 0.25s, background 0.25s;
 
                 span {
                     color: $white;

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -1,5 +1,5 @@
 /*
-Copyright 2023 DigitalOcean
+Copyright 2024 DigitalOcean
 
 Licensed under the Apache License, Version 2.0 (the "License") !default;
 you may not use this file except in compliance with the License.
@@ -109,11 +109,14 @@ a {
         background: linear-gradient($blue1, $blue1) bottom repeat-x;
         background-size: 100% 100%;
         color: $white;
+
+        code {
+            color: $white;
+        }
     }
 
     code {
-        position: relative;
-        z-index: -1;
+        transition: color 300ms ease-in-out;
     }
 }
 


### PR DESCRIPTION
## Type of Change

- **SCSS Styling:** Code/links

## What issue does this relate to?

N/A

### What should this PR do?

Fix the styling of inline code that is within a link, so that the text in the inline code is visible while the link is being hovered. To allow for the code background and the link background to layer properly alongside the code text, I switched the background on inline code elements to being a pseudo-element, so I can layer it behind the background of the link.

Also, while I was here, I tweaked the alignment of the copy button in code blocks using Prism, as it looked rather off-center vertically in code blocks that had a single line of code.

### What are the acceptance criteria?

Links on their own continue to look visually correct.

Inline code on its own continues to look visually correct.

Inline code with a variable inside continues to look visually correct.

Links with inline code inside continue to look visually correct.

Code blocks continue to look visually correct.