### PR TITLE
Fix multi-line inline code styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ Any non-code changes should be prefixed with `(docs)`.
 See `PUBLISH.md` for instructions on how to publish a new version.
 -->
 
+- (patch) Fix multi-line inline code styling
+
 
 ## v1.12.5 - fc90098
 

--- a/styles/_code.scss
+++ b/styles/_code.scss
@@ -20,20 +20,11 @@ limitations under the License.
 // Inline code
 pre,
 code {
+    background-color: $gray8;
+    border-radius: 0.5em;
     color: $gray3;
     font-size: 0.875em;
-    padding: 0 0.2em;
-    position: relative;
-
-    &::before {
-        background-color: $gray8;
-        border-radius: 0.5em;
-        content: "";
-        display: block;
-        inset: -0.2em 0;
-        position: absolute;
-        z-index: -1;
-    }
+    padding: 0.2em;
 }
 
 // Code blocks
@@ -50,14 +41,9 @@ pre {
     white-space: normal;
     word-wrap: normal;
 
-    &,
     code {
-        &::before {
-            display: none;
-        }
-    }
-
-    code {
+        background: none;
+        border-radius: 0;
         color: inherit;
         font-size: 1em;
         padding: 0;

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -109,13 +109,17 @@ a {
         color: $white;
 
         code {
-            background: linear-gradient($blue1, $blue1) center calc(100% - 0.2em + 0.5px) / 100% calc(100% - (0.2em * 2)) no-repeat, linear-gradient($gray8, $gray8);
+            background:
+                linear-gradient($blue2, $blue2) center calc(100% - 0.2em + 0.5px) / 100% 1px no-repeat,
+                linear-gradient($gray8, $gray8) center top / 100% 0% no-repeat;
             color: $white;
         }
     }
 
     code {
-        background: linear-gradient($blue2, $blue2) center calc(100% - 0.2em + 0.5px) / 100% 1px no-repeat, linear-gradient($gray8, $gray8);
+        background:
+            linear-gradient($blue2, $blue2) center calc(100% - 0.2em + 0.5px) / 100% 1px no-repeat,
+            linear-gradient($gray8, $gray8) center top / 100% 100% no-repeat;
         transition:
             background 300ms ease-in-out,
             color 300ms ease-in-out;

--- a/styles/_typography.scss
+++ b/styles/_typography.scss
@@ -95,8 +95,7 @@ ol {
 
 // Links
 a {
-    background: linear-gradient($blue2, $blue2) bottom repeat-x;
-    background-size: 1px 1px;
+    background: linear-gradient($blue2, $blue2) center bottom / 100% 1px no-repeat;
     border-bottom: none;
     color: $blue2;
     text-decoration: none;
@@ -106,17 +105,20 @@ a {
 
     &:hover,
     &:focus {
-        background: linear-gradient($blue1, $blue1) bottom repeat-x;
-        background-size: 100% 100%;
+        background: linear-gradient($blue1, $blue1) center bottom / 100% 100% no-repeat;
         color: $white;
 
         code {
+            background: linear-gradient($blue1, $blue1) center calc(100% - 0.2em + 0.5px) / 100% calc(100% - (0.2em * 2)) no-repeat, linear-gradient($gray8, $gray8);
             color: $white;
         }
     }
 
     code {
-        transition: color 300ms ease-in-out;
+        background: linear-gradient($blue2, $blue2) center calc(100% - 0.2em + 0.5px) / 100% 1px no-repeat, linear-gradient($gray8, $gray8);
+        transition:
+            background 300ms ease-in-out,
+            color 300ms ease-in-out;
     }
 }
 


### PR DESCRIPTION
## Type of Change

- **SCSS Styling:** Code/links

## What issue does this relate to?

cc #103

### What should this PR do?

While #103 did fix the more prevalent issue of inline code in links becoming unreadable when hovered, that fix ended up breaking the less common situation of inline code spanning across a linebreak (due to the background now being a pseudo-element rather than an actual background).

To fix this, I've partially reverted the change the previous PR made, sticking to using just a regular old background for inline code, and have then changed how inline code inside a link gets styled to use multiple background layers to combine the link treatment with the inline code background seamlessly.

### What are the acceptance criteria?

- Inline code, including across linebreaks, has a background
- Inline code, inside a link, including across linebreaks, has a background
- Regular text, inside a link, including across linebreaks, has a background

I have been using this snippet to test:

```
`this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code.` this is not inline code

[`this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code. this is a really long bit of inline code.` this is not inline code]()
```

<img width="1002" alt="image" src="https://github.com/digitalocean/do-markdownit/assets/12371363/75808a21-edc3-4f8e-8199-3a1a0321f5a9">

<img width="998" alt="image" src="https://github.com/digitalocean/do-markdownit/assets/12371363/5a0f6101-6cc0-41c1-a7b2-88cd20f4a796">
