### PR TITLE
Set --skipLibCheck for tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "lint:scss": "stylelint \"@(styles|dev)/**/*.scss\"",
     "lint:scss:fix": "npm run lint:scss -- --fix",
     "jsdoc": "jsdoc -c .jsdoc.json",
-    "types": "tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir types --lib dom --lib webworker",
+    "types": "tsc index.js --declaration --allowJs --emitDeclarationOnly --outDir types --lib dom --lib webworker --skipLibCheck",
     "test": "jest",
     "postinstall": "node script/prism.js",
     "prepublishOnly": "npm run types",


### PR DESCRIPTION
## Type of Change

- **Something else:** Release tooling

## What issue does this relate to?

N/A

### What should this PR do?

Disables type checking for dependencies, as there appears to be type issues within `@types/eslint-scope`.

```
node_modules/@types/eslint-scope/index.d.ts:12:5 - error TS2416: Property 'scopes' in type 'ScopeManager' is not assignable to the same property in base type 'ScopeManager'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope[]'.
    Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope'.
      Types of property 'variables' are incompatible.
        Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Variable[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Variable[]'.
          Property 'scope' is missing in type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Variable' but required in type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Variable'.

12     scopes: Scope[];
       ~~~~~~

  node_modules/@types/eslint/index.d.ts:78:9
    78         scope: Scope;
               ~~~~~
    'scope' is declared here.

node_modules/@types/eslint-scope/index.d.ts:13:5 - error TS2416: Property 'globalScope' in type 'ScopeManager' is not assignable to the same property in base type 'ScopeManager'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope'.

13     globalScope: Scope;
       ~~~~~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:14:5 - error TS2416: Property 'acquire' in type 'ScopeManager' is not assignable to the same property in base type 'ScopeManager'.
  Type '(node: {}, inner?: boolean) => Scope' is not assignable to type '(node: Node, inner?: boolean) => Scope'.
    Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope'.

14     acquire(node: {}, inner?: boolean): Scope | null;
       ~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:15:5 - error TS2416: Property 'getDeclaredVariables' in type 'ScopeManager' is not assignable to the same property in base type 'ScopeManager'.
  Type '(node: {}) => Variable[]' is not assignable to type '(node: Node) => Variable[]'.
    Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Variable[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Variable[]'.

15     getDeclaredVariables(node: {}): Variable[];
       ~~~~~~~~~~~~~~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:21:5 - error TS2416: Property 'upper' in type 'Scope' is not assignable to the same property in base type 'Scope'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope'.

21     upper: Scope | null;
       ~~~~~

node_modules/@types/eslint-scope/index.d.ts:22:5 - error TS2416: Property 'childScopes' in type 'Scope' is not assignable to the same property in base type 'Scope'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope[]'.

22     childScopes: Scope[];
       ~~~~~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:23:5 - error TS2416: Property 'variableScope' in type 'Scope' is not assignable to the same property in base type 'Scope'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope'.

23     variableScope: Scope;
       ~~~~~~~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:25:5 - error TS2416: Property 'variables' in type 'Scope' is not assignable to the same property in base type 'Scope'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Variable[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Variable[]'.

25     variables: Variable[];
       ~~~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:26:5 - error TS2416: Property 'set' in type 'Scope' is not assignable to the same property in base type 'Scope'.
  Type 'Map<string, import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Variable>' is not assignable to type 'Map<string, import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Variable>'.
    Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Variable' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Variable'.

26     set: Map<string, Variable>;
       ~~~

node_modules/@types/eslint-scope/index.d.ts:27:5 - error TS2416: Property 'references' in type 'Scope' is not assignable to the same property in base type 'Scope'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Reference[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Reference[]'.
    Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Reference' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Reference'.
      Types of property 'from' are incompatible.
        Type 'import("/[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope'.

27     references: Reference[];
       ~~~~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:28:5 - error TS2416: Property 'through' in type 'Scope' is not assignable to the same property in base type 'Scope'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Reference[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Reference[]'.

28     through: Reference[];
       ~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:35:5 - error TS2416: Property 'references' in type 'Variable' is not assignable to the same property in base type 'Variable'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Reference[]' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Reference[]'.

35     references: Reference[];
       ~~~~~~~~~~

node_modules/@types/eslint-scope/index.d.ts:41:5 - error TS2416: Property 'from' in type 'Reference' is not assignable to the same property in base type 'Reference'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Scope' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Scope'.

41     from: Scope;
       ~~~~

node_modules/@types/eslint-scope/index.d.ts:42:5 - error TS2416: Property 'resolved' in type 'Reference' is not assignable to the same property in base type 'Reference'.
  Type 'import("[snip]/do-markdownit/node_modules/@types/eslint-scope/index").Variable' is not assignable to type 'import("[snip]/do-markdownit/node_modules/@types/eslint/index").Scope.Variable'.

42     resolved: Variable | null;
       ~~~~~~~~


Found 14 errors in the same file, starting at: node_modules/@types/eslint-scope/index.d.ts:12
```

### What are the acceptance criteria?

`npm publish --dry-run` works w/o error.
